### PR TITLE
Implementacion de i18n

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -28,6 +28,6 @@ Strings are defined per locale under the **TravelHub** app:
 5. **Interpolation** — Use `{{name}}` in JSON and pass values: `t('searchPage.staysIn', { city: cityName })`.
 6. **Plurals** — Use `_one` / `_other` (and other plural forms as needed) under the same parent key, then call `t('search.guestsCount', { count: n })`. Add matching plural keys in both locale files.
 
-The i18n instance is configured in [`travel-hub/lib/i18n/client.ts`](./travel-hub/lib/i18n/client.ts); the app is wrapped with `I18nProvider` in [`travel-hub/app/layout.tsx`](./travel-hub/app/layout.tsx). For tests, use `renderWithI18n` from [`travel-hub/__tests__/test-utils.tsx`](./travel-hub/__tests__/test-utils.tsx).
+The i18n instance is configured in [`travel-hub/lib/i18n/client.ts`](./travel-hub/lib/i18n/client.ts); the app is wrapped with `I18nProvider` in [`travel-hub/app/layout.tsx`](./travel-hub/app/layout.tsx). After hydration, [`LanguageSync`](./travel-hub/components/i18n/LanguageSync.tsx) applies the user’s saved language from `localStorage` (or the browser language when nothing is saved) so the first server render and the first client render both use **`en-US`**, avoiding React hydration mismatches. For tests, use `renderWithI18n` from [`travel-hub/__tests__/test-utils.tsx`](./travel-hub/__tests__/test-utils.tsx).
 
-**Locales:** `en-US` (default) and `es-CO`. The navbar language toggle switches between them; the choice is stored in `localStorage` (`i18nextLng`).
+**Locales:** `en-US` (default for SSR and first paint) and `es-CO`. The navbar language toggle switches between them; changes are persisted under `localStorage` (`i18nextLng`).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,1 +1,33 @@
-# Frontend Repo
+# Frontend
+
+The web app lives in [`travel-hub/`](./travel-hub/) (Next.js).
+
+## Adding translated strings (i18next)
+
+Strings are defined per locale under the **TravelHub** app:
+
+- English (US): [`travel-hub/lib/i18n/locales/en-US/common.json`](./travel-hub/lib/i18n/locales/en-US/common.json)
+- Spanish (Colombia): [`travel-hub/lib/i18n/locales/es-CO/common.json`](./travel-hub/lib/i18n/locales/es-CO/common.json)
+
+**Workflow**
+
+1. **Pick a key** — Use dot notation and group by feature, for example `search.placeholder`, `nav.logIn`, `footer.support.title`. Keep the same structure in both JSON files.
+2. **Add the English text** under the matching path in `en-US/common.json`.
+3. **Add the Spanish (Colombia) text** under the same path in `es-CO/common.json`.
+4. **Use it in UI** — In a **client component** (`'use client'`), call `useTranslation()` from `react-i18next` and render `t('your.key')`:
+
+   ```tsx
+   import { useTranslation } from 'react-i18next';
+
+   export function Example() {
+     const { t } = useTranslation();
+     return <p>{t('search.searchDestination')}</p>;
+   }
+   ```
+
+5. **Interpolation** — Use `{{name}}` in JSON and pass values: `t('searchPage.staysIn', { city: cityName })`.
+6. **Plurals** — Use `_one` / `_other` (and other plural forms as needed) under the same parent key, then call `t('search.guestsCount', { count: n })`. Add matching plural keys in both locale files.
+
+The i18n instance is configured in [`travel-hub/lib/i18n/client.ts`](./travel-hub/lib/i18n/client.ts); the app is wrapped with `I18nProvider` in [`travel-hub/app/layout.tsx`](./travel-hub/app/layout.tsx). For tests, use `renderWithI18n` from [`travel-hub/__tests__/test-utils.tsx`](./travel-hub/__tests__/test-utils.tsx).
+
+**Locales:** `en-US` (default) and `es-CO`. The navbar language toggle switches between them; the choice is stored in `localStorage` (`i18nextLng`).

--- a/frontend/travel-hub/__tests__/amenity-filter.test.tsx
+++ b/frontend/travel-hub/__tests__/amenity-filter.test.tsx
@@ -1,7 +1,8 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import AmenityFilter from '../components/traveler/AmenityFilter';
+import { renderWithI18n } from '@/__tests__/test-utils';
 
 const AMENITIES = [
   { code: 'wifi', name: 'Wi-Fi' },
@@ -11,7 +12,7 @@ const AMENITIES = [
 
 describe('AmenityFilter', () => {
   it('renders the title and all amenity options', () => {
-    render(<AmenityFilter amenities={AMENITIES} selected={[]} onChange={vi.fn()} />);
+    renderWithI18n(<AmenityFilter amenities={AMENITIES} selected={[]} onChange={vi.fn()} />);
     expect(screen.getByText('Amenities')).toBeTruthy();
     expect(screen.getByLabelText('Wi-Fi')).toBeTruthy();
     expect(screen.getByLabelText('Piscina')).toBeTruthy();
@@ -19,7 +20,7 @@ describe('AmenityFilter', () => {
   });
 
   it('checks checkboxes for selected amenities', () => {
-    render(<AmenityFilter amenities={AMENITIES} selected={['wifi', 'pool']} onChange={vi.fn()} />);
+    renderWithI18n(<AmenityFilter amenities={AMENITIES} selected={['wifi', 'pool']} onChange={vi.fn()} />);
     expect((screen.getByLabelText('Wi-Fi') as HTMLInputElement).checked).toBe(true);
     expect((screen.getByLabelText('Piscina') as HTMLInputElement).checked).toBe(true);
     expect((screen.getByLabelText('Desayuno incluido') as HTMLInputElement).checked).toBe(false);
@@ -27,7 +28,7 @@ describe('AmenityFilter', () => {
 
   it('calls onChange with correct codes when toggled', () => {
     const onChange = vi.fn();
-    render(<AmenityFilter amenities={AMENITIES} selected={['wifi']} onChange={onChange} />);
+    renderWithI18n(<AmenityFilter amenities={AMENITIES} selected={['wifi']} onChange={onChange} />);
     fireEvent.click(screen.getByLabelText('Piscina'));
     expect(onChange).toHaveBeenCalledWith(['wifi', 'pool']);
     fireEvent.click(screen.getByLabelText('Wi-Fi'));

--- a/frontend/travel-hub/__tests__/price-range-filter.test.tsx
+++ b/frontend/travel-hub/__tests__/price-range-filter.test.tsx
@@ -1,24 +1,25 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import PriceRangeFilter from '../components/traveler/PriceRangeFilter';
+import { renderWithI18n } from '@/__tests__/test-utils';
 
 describe('PriceRangeFilter', () => {
   it('renders the title and subtitle', () => {
-    render(<PriceRangeFilter onApply={vi.fn()} />);
+    renderWithI18n(<PriceRangeFilter onApply={vi.fn()} />);
     expect(screen.getByText('Price range')).toBeTruthy();
     expect(screen.getByText('Nightly prices before fees and taxes')).toBeTruthy();
   });
 
   it('renders min and max text fields', () => {
-    render(<PriceRangeFilter onApply={vi.fn()} />);
+    renderWithI18n(<PriceRangeFilter onApply={vi.fn()} />);
     expect(screen.getByLabelText('Min')).toBeTruthy();
     expect(screen.getByLabelText('Max')).toBeTruthy();
   });
 
   it('calls onApply with price values on blur', () => {
     const onApply = vi.fn();
-    render(<PriceRangeFilter minPrice={100} maxPrice={500} onApply={onApply} />);
+    renderWithI18n(<PriceRangeFilter minPrice={100} maxPrice={500} onApply={onApply} />);
 
     fireEvent.blur(screen.getByLabelText('Min'));
 
@@ -27,7 +28,7 @@ describe('PriceRangeFilter', () => {
 
   it('shows validation error when min > max on blur', () => {
     const onApply = vi.fn();
-    render(<PriceRangeFilter onApply={onApply} />);
+    renderWithI18n(<PriceRangeFilter onApply={onApply} />);
 
     const minInput = screen.getByLabelText('Min');
     const maxInput = screen.getByLabelText('Max');
@@ -42,7 +43,7 @@ describe('PriceRangeFilter', () => {
 
   it('clears error when input changes after validation error', () => {
     const onApply = vi.fn();
-    render(<PriceRangeFilter onApply={onApply} />);
+    renderWithI18n(<PriceRangeFilter onApply={onApply} />);
 
     const minInput = screen.getByLabelText('Min');
     const maxInput = screen.getByLabelText('Max');
@@ -58,7 +59,7 @@ describe('PriceRangeFilter', () => {
 
   it('allows equal min and max price', () => {
     const onApply = vi.fn();
-    render(<PriceRangeFilter minPrice={200} maxPrice={200} onApply={onApply} />);
+    renderWithI18n(<PriceRangeFilter minPrice={200} maxPrice={200} onApply={onApply} />);
 
     fireEvent.blur(screen.getByLabelText('Min'));
 

--- a/frontend/travel-hub/__tests__/property-detail.test.tsx
+++ b/frontend/travel-hub/__tests__/property-detail.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import PropertyDetailView from '@/components/traveler/PropertyDetailView';
+import { renderWithI18n } from '@/__tests__/test-utils';
 import { CatalogNotFoundError, getPropertyDetail } from '@/app/lib/api/catalog';
 import type { PropertyDetailResponse } from '@/app/lib/types/catalog';
 
@@ -122,13 +123,13 @@ describe('PropertyDetailView', () => {
 
   it('shows loading spinner initially', () => {
     mockGetPropertyDetail.mockReturnValue(new Promise(() => {})); // never resolves
-    render(<PropertyDetailView id={PROPERTY_ID} />);
+    renderWithI18n(<PropertyDetailView id={PROPERTY_ID} />);
     expect(screen.getByRole('progressbar')).toBeTruthy();
   });
 
   it('renders property name after load', async () => {
     mockGetPropertyDetail.mockResolvedValue(makeDetailResponse());
-    render(<PropertyDetailView id={PROPERTY_ID} />);
+    renderWithI18n(<PropertyDetailView id={PROPERTY_ID} />);
 
     await waitFor(() => {
       expect(screen.getByRole('heading', { level: 1 })).toBeTruthy();
@@ -138,7 +139,7 @@ describe('PropertyDetailView', () => {
 
   it('renders rating value after load', async () => {
     mockGetPropertyDetail.mockResolvedValue(makeDetailResponse());
-    render(<PropertyDetailView id={PROPERTY_ID} />);
+    renderWithI18n(<PropertyDetailView id={PROPERTY_ID} />);
 
     await waitFor(() => {
       expect(screen.getAllByText('4.8').length).toBeGreaterThan(0);
@@ -147,7 +148,7 @@ describe('PropertyDetailView', () => {
 
   it('renders the property description', async () => {
     mockGetPropertyDetail.mockResolvedValue(makeDetailResponse());
-    render(<PropertyDetailView id={PROPERTY_ID} />);
+    renderWithI18n(<PropertyDetailView id={PROPERTY_ID} />);
 
     await waitFor(() => {
       expect(screen.getByText('A wonderful place to stay in the city center.')).toBeTruthy();
@@ -156,7 +157,7 @@ describe('PropertyDetailView', () => {
 
   it('renders amenities', async () => {
     mockGetPropertyDetail.mockResolvedValue(makeDetailResponse());
-    render(<PropertyDetailView id={PROPERTY_ID} />);
+    renderWithI18n(<PropertyDetailView id={PROPERTY_ID} />);
 
     await waitFor(() => {
       expect(screen.getByText('Ultra fast Wi-Fi')).toBeTruthy();
@@ -166,7 +167,7 @@ describe('PropertyDetailView', () => {
 
   it('renders available room types', async () => {
     mockGetPropertyDetail.mockResolvedValue(makeDetailResponse());
-    render(<PropertyDetailView id={PROPERTY_ID} />);
+    renderWithI18n(<PropertyDetailView id={PROPERTY_ID} />);
 
     await waitFor(() => {
       expect(screen.getByText('Deluxe King Room')).toBeTruthy();
@@ -175,7 +176,7 @@ describe('PropertyDetailView', () => {
 
   it('renders reviews', async () => {
     mockGetPropertyDetail.mockResolvedValue(makeDetailResponse());
-    render(<PropertyDetailView id={PROPERTY_ID} />);
+    renderWithI18n(<PropertyDetailView id={PROPERTY_ID} />);
 
     await waitFor(() => {
       expect(screen.getByText('Amazing hotel! The service was impeccable.')).toBeTruthy();
@@ -185,7 +186,7 @@ describe('PropertyDetailView', () => {
 
   it('renders breadcrumbs with city and country', async () => {
     mockGetPropertyDetail.mockResolvedValue(makeDetailResponse());
-    render(<PropertyDetailView id={PROPERTY_ID} />);
+    renderWithI18n(<PropertyDetailView id={PROPERTY_ID} />);
 
     await waitFor(() => {
       // City name appears in breadcrumb link
@@ -196,7 +197,7 @@ describe('PropertyDetailView', () => {
 
   it('renders free cancellation chip when policy is FULL', async () => {
     mockGetPropertyDetail.mockResolvedValue(makeDetailResponse());
-    render(<PropertyDetailView id={PROPERTY_ID} />);
+    renderWithI18n(<PropertyDetailView id={PROPERTY_ID} />);
 
     await waitFor(() => {
       expect(screen.getByText('Free cancellation')).toBeTruthy();
@@ -205,7 +206,7 @@ describe('PropertyDetailView', () => {
 
   it('renders price per night in the price card', async () => {
     mockGetPropertyDetail.mockResolvedValue(makeDetailResponse());
-    render(<PropertyDetailView id={PROPERTY_ID} />);
+    renderWithI18n(<PropertyDetailView id={PROPERTY_ID} />);
 
     await waitFor(() => {
       expect(screen.getAllByText('$199').length).toBeGreaterThan(0);
@@ -214,7 +215,7 @@ describe('PropertyDetailView', () => {
 
   it('shows error message and retry button on non-404 API failure', async () => {
     mockGetPropertyDetail.mockRejectedValue(new Error('Error de red'));
-    render(<PropertyDetailView id={PROPERTY_ID} />);
+    renderWithI18n(<PropertyDetailView id={PROPERTY_ID} />);
 
     await waitFor(() => {
       expect(screen.getByText('Error de red')).toBeTruthy();
@@ -224,7 +225,7 @@ describe('PropertyDetailView', () => {
 
   it('shows shared 404 view when hotel does not exist (API 404)', async () => {
     mockGetPropertyDetail.mockRejectedValue(new CatalogNotFoundError());
-    render(<PropertyDetailView id={PROPERTY_ID} />);
+    renderWithI18n(<PropertyDetailView id={PROPERTY_ID} />);
 
     await waitFor(() => {
       expect(screen.getByText('Alojamiento no encontrado')).toBeTruthy();
@@ -234,7 +235,7 @@ describe('PropertyDetailView', () => {
 
   it('passes property id to getPropertyDetail', async () => {
     mockGetPropertyDetail.mockResolvedValue(makeDetailResponse());
-    render(<PropertyDetailView id="my-special-id" />);
+    renderWithI18n(<PropertyDetailView id="my-special-id" />);
 
     await waitFor(() => {
       expect(mockGetPropertyDetail).toHaveBeenCalledWith('my-special-id', expect.objectContaining({}));
@@ -243,7 +244,7 @@ describe('PropertyDetailView', () => {
 
   it('renders property with no images gracefully', async () => {
     mockGetPropertyDetail.mockResolvedValue(makeDetailResponse({ images: [] }));
-    render(<PropertyDetailView id={PROPERTY_ID} />);
+    renderWithI18n(<PropertyDetailView id={PROPERTY_ID} />);
 
     await waitFor(() => {
       expect(screen.getByText('No images available')).toBeTruthy();
@@ -252,7 +253,7 @@ describe('PropertyDetailView', () => {
 
   it('renders property with no description gracefully', async () => {
     mockGetPropertyDetail.mockResolvedValue(makeDetailResponse({ description: null }));
-    render(<PropertyDetailView id={PROPERTY_ID} />);
+    renderWithI18n(<PropertyDetailView id={PROPERTY_ID} />);
 
     await waitFor(() => {
       expect(screen.getAllByText('Grand Hotel Test').length).toBeGreaterThan(0);
@@ -262,7 +263,7 @@ describe('PropertyDetailView', () => {
 
   it('shows aggregate rating and review count in header when data exists', async () => {
     mockGetPropertyDetail.mockResolvedValue(makeDetailResponse());
-    render(<PropertyDetailView id={PROPERTY_ID} />);
+    renderWithI18n(<PropertyDetailView id={PROPERTY_ID} />);
 
     await waitFor(() => {
       expect(screen.getByText('(2.4k reviews)')).toBeTruthy();
@@ -283,7 +284,7 @@ describe('PropertyDetailView', () => {
       },
     });
 
-    render(<PropertyDetailView id={PROPERTY_ID} />);
+    renderWithI18n(<PropertyDetailView id={PROPERTY_ID} />);
 
     await waitFor(() => {
       const unavailable = screen.getAllByText('Rating not available');
@@ -310,7 +311,7 @@ describe('PropertyCard links to detail page', () => {
       amenities: [],
     };
 
-    render(<PropertyCard property={property} />);
+    renderWithI18n(<PropertyCard property={property} />);
 
     const link = screen.getByRole('link');
     expect(link.getAttribute('href')).toBe('/traveler/hotel?id=prop-123');

--- a/frontend/travel-hub/__tests__/root-page.test.tsx
+++ b/frontend/travel-hub/__tests__/root-page.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import RootPage from '@/app/page';
+import { renderWithI18n } from '@/__tests__/test-utils';
 import * as authApi from '@/app/lib/api/auth';
 import * as catalogApi from '@/app/lib/api/catalog';
 
@@ -33,18 +34,18 @@ describe('Home page', () => {
   });
 
   it('renders the hero heading', async () => {
-    render(<RootPage />);
+    renderWithI18n(<RootPage />);
     expect(screen.getByText('Find your next stay')).toBeTruthy();
   });
 
   it('renders the navbar with TravelHub branding', async () => {
-    render(<RootPage />);
+    renderWithI18n(<RootPage />);
     expect(screen.getByText('TravelHub')).toBeTruthy();
   });
 
   it('shows Log in link when not authenticated', async () => {
     mockGetMe.mockResolvedValue(null);
-    render(<RootPage />);
+    renderWithI18n(<RootPage />);
     await waitFor(() => {
       expect(screen.getByText('Log in')).toBeTruthy();
     });
@@ -52,29 +53,29 @@ describe('Home page', () => {
 
   it('shows username when authenticated', async () => {
     mockGetMe.mockResolvedValue({ id: '1', email: 'john@test.com', role: 'TRAVELER' });
-    render(<RootPage />);
+    renderWithI18n(<RootPage />);
     await waitFor(() => {
       expect(screen.getByText('john')).toBeTruthy();
     });
   });
 
   it('renders the Popular Destinations section', () => {
-    render(<RootPage />);
+    renderWithI18n(<RootPage />);
     expect(screen.getByText('Popular Destinations')).toBeTruthy();
   });
 
   it('renders the Recommended for You section', () => {
-    render(<RootPage />);
+    renderWithI18n(<RootPage />);
     expect(screen.getByText('Recommended for You')).toBeTruthy();
   });
 
   it('renders the newsletter section', () => {
-    render(<RootPage />);
+    renderWithI18n(<RootPage />);
     expect(screen.getByText('Plan your dream getaway today')).toBeTruthy();
   });
 
   it('renders the search destination input', () => {
-    render(<RootPage />);
+    renderWithI18n(<RootPage />);
     expect(screen.getByPlaceholderText('Search destination')).toBeTruthy();
   });
 });

--- a/frontend/travel-hub/__tests__/search-page.test.tsx
+++ b/frontend/travel-hub/__tests__/search-page.test.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import SearchPage from '@/app/traveler/search/page';
+import { renderWithI18n } from '@/__tests__/test-utils';
 import { getFeaturedProperties, searchCities, searchProperties } from '@/app/lib/api/catalog';
 
 // Mock useSearchParams to return an empty URLSearchParams by default
@@ -73,7 +74,7 @@ describe('SearchPage', () => {
   });
 
   it('renders the price range filter on the page', async () => {
-    render(<SearchPage />);
+    renderWithI18n(<SearchPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Price range')).toBeTruthy();
@@ -83,7 +84,7 @@ describe('SearchPage', () => {
   });
 
   it('loads featured stays on mount without calling filtered search', async () => {
-    render(<SearchPage />);
+    renderWithI18n(<SearchPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Hotel Test')).toBeTruthy();
@@ -93,7 +94,7 @@ describe('SearchPage', () => {
   });
 
   it('keeps search disabled without a destination and does not call searchProperties', async () => {
-    render(<SearchPage />);
+    renderWithI18n(<SearchPage />);
 
     await waitFor(() => screen.getByText('Hotel Test'));
 
@@ -113,7 +114,7 @@ describe('SearchPage', () => {
       { id: 'city-enable', name: 'Medellín', department: 'Antioquia', country: 'Colombia' },
     ]);
 
-    render(<SearchPage />);
+    renderWithI18n(<SearchPage />);
     await waitFor(() => screen.getByText('Hotel Test'));
 
     const searchButtons = screen.getAllByRole('button');
@@ -142,7 +143,7 @@ describe('SearchPage', () => {
       { id: 'city-uuid-1', name: 'Medellín', department: 'Antioquia', country: 'Colombia' },
     ]);
 
-    render(<SearchPage />);
+    renderWithI18n(<SearchPage />);
     await waitFor(() => screen.getByText('Hotel Test'));
 
     const input = screen.getByPlaceholderText(/search destination/i);
@@ -183,7 +184,7 @@ describe('SearchPage', () => {
       { id: 'city-uuid-1', name: 'Medellín', department: 'Antioquia', country: 'Colombia' },
     ]);
 
-    render(<SearchPage />);
+    renderWithI18n(<SearchPage />);
     await waitFor(() => screen.getByText('Hotel Test'));
 
     const input = screen.getByPlaceholderText(/search destination/i);
@@ -223,7 +224,7 @@ describe('SearchPage', () => {
       { id: 'cid-sort', name: 'Q', department: null, country: 'Z' },
     ]);
 
-    render(<SearchPage />);
+    renderWithI18n(<SearchPage />);
     await waitFor(() => screen.getByText('Hotel Test'));
 
     const input = screen.getByPlaceholderText(/search destination/i);
@@ -259,7 +260,7 @@ describe('SearchPage', () => {
   });
 
   it('does not call searchProperties when changing guests in browse mode (no city)', async () => {
-    render(<SearchPage />);
+    renderWithI18n(<SearchPage />);
 
     await waitFor(() => screen.getByText('Hotel Test'));
     mockSearch.mockClear();
@@ -276,7 +277,7 @@ describe('SearchPage', () => {
   });
 
   it('applies price filter client-side in browse mode without extra API calls', async () => {
-    render(<SearchPage />);
+    renderWithI18n(<SearchPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Hotel Test')).toBeTruthy();
@@ -296,7 +297,7 @@ describe('SearchPage', () => {
   });
 
   it('displays result count', async () => {
-    render(<SearchPage />);
+    renderWithI18n(<SearchPage />);
 
     await waitFor(() => {
       expect(screen.getByText(/2 places? found/)).toBeTruthy();
@@ -305,7 +306,7 @@ describe('SearchPage', () => {
 
   it('shows empty state when browse filters exclude all properties', async () => {
     mockFeatured.mockResolvedValue(mockItems);
-    render(<SearchPage />);
+    renderWithI18n(<SearchPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Hotel Test')).toBeTruthy();
@@ -327,7 +328,7 @@ describe('SearchPage', () => {
     ]);
     mockSearch.mockResolvedValue(emptyResponse);
 
-    render(<SearchPage />);
+    renderWithI18n(<SearchPage />);
     await waitFor(() => screen.getByText('Hotel Test'));
 
     const input = screen.getByPlaceholderText(/search destination/i);
@@ -350,7 +351,7 @@ describe('SearchPage', () => {
 
   it('shows readable error message on API failure', async () => {
     mockFeatured.mockRejectedValue(new Error('Network error'));
-    render(<SearchPage />);
+    renderWithI18n(<SearchPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Network error')).toBeTruthy();
@@ -361,7 +362,7 @@ describe('SearchPage', () => {
     mockFeatured.mockRejectedValue(
       new Error('Field required')
     );
-    render(<SearchPage />);
+    renderWithI18n(<SearchPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Field required')).toBeTruthy();
@@ -369,7 +370,7 @@ describe('SearchPage', () => {
   });
 
   it('re-fetches with amenities when an amenity checkbox is toggled in browse mode', async () => {
-    render(<SearchPage />);
+    renderWithI18n(<SearchPage />);
     await waitFor(() => screen.getByText('Hotel Test'));
 
     fireEvent.click(screen.getByRole('checkbox', { name: /wifi/i }));
@@ -386,7 +387,7 @@ describe('SearchPage', () => {
       { id: 'cid', name: 'Q', department: null, country: 'Z' },
     ]);
 
-    render(<SearchPage />);
+    renderWithI18n(<SearchPage />);
     await waitFor(() => screen.getByText('Hotel Test'));
 
     const input = screen.getByPlaceholderText(/search destination/i);
@@ -417,7 +418,7 @@ describe('SearchPage', () => {
     }));
     mockFeatured.mockResolvedValue(many);
 
-    render(<SearchPage />);
+    renderWithI18n(<SearchPage />);
 
     await waitFor(() => {
       expect(screen.getByRole('navigation')).toBeTruthy();

--- a/frontend/travel-hub/__tests__/test-utils.tsx
+++ b/frontend/travel-hub/__tests__/test-utils.tsx
@@ -1,0 +1,12 @@
+import { render, type RenderOptions } from '@testing-library/react';
+import type { ReactElement, ReactNode } from 'react';
+
+import { I18nProvider } from '@/components/i18n/I18nProvider';
+
+function AllProviders({ children }: { children: ReactNode }) {
+  return <I18nProvider>{children}</I18nProvider>;
+}
+
+export function renderWithI18n(ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) {
+  return render(ui, { wrapper: AllProviders, ...options });
+}

--- a/frontend/travel-hub/app/layout.tsx
+++ b/frontend/travel-hub/app/layout.tsx
@@ -6,6 +6,10 @@ import { ThemeProvider } from '@mui/material/styles';
 import './globals.css';
 import { roboto, theme } from './theme';
 
+import { DocumentLang } from '@/components/i18n/DocumentLang';
+import { I18nProvider } from '@/components/i18n/I18nProvider';
+import { TranslatedMeta } from '@/components/i18n/TranslatedMeta';
+
 export const metadata: Metadata = {
   title: 'TravelHub — Find Your Next Stay',
   description: 'Unlock exclusive deals on hotels, homes, and more across Latin America.',
@@ -17,11 +21,15 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={roboto.variable}>
+    <html lang="en-US" className={roboto.variable} suppressHydrationWarning>
       <body className="min-h-full flex flex-col" suppressHydrationWarning>
-        <AppRouterCacheProvider>
-          <ThemeProvider theme={theme}>{children}</ThemeProvider>
-        </AppRouterCacheProvider>
+        <I18nProvider>
+          <DocumentLang />
+          <TranslatedMeta />
+          <AppRouterCacheProvider>
+            <ThemeProvider theme={theme}>{children}</ThemeProvider>
+          </AppRouterCacheProvider>
+        </I18nProvider>
       </body>
     </html>
   );

--- a/frontend/travel-hub/app/layout.tsx
+++ b/frontend/travel-hub/app/layout.tsx
@@ -8,6 +8,7 @@ import { roboto, theme } from './theme';
 
 import { DocumentLang } from '@/components/i18n/DocumentLang';
 import { I18nProvider } from '@/components/i18n/I18nProvider';
+import { LanguageSync } from '@/components/i18n/LanguageSync';
 import { TranslatedMeta } from '@/components/i18n/TranslatedMeta';
 
 export const metadata: Metadata = {
@@ -24,6 +25,7 @@ export default function RootLayout({
     <html lang="en-US" className={roboto.variable} suppressHydrationWarning>
       <body className="min-h-full flex flex-col" suppressHydrationWarning>
         <I18nProvider>
+          <LanguageSync />
           <DocumentLang />
           <TranslatedMeta />
           <AppRouterCacheProvider>

--- a/frontend/travel-hub/app/traveler/search/page.tsx
+++ b/frontend/travel-hub/app/traveler/search/page.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
 
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
@@ -20,6 +21,7 @@ import SearchBar from '@/components/search/SearchBar';
 
 import { getFeaturedProperties, searchProperties } from '@/app/lib/api/catalog';
 import type { AmenitySummary, CityOut, PaginatedResponse, PropertySummary } from '@/app/lib/types/catalog';
+import { dateFormattingLocale } from '@/lib/i18n/dateLocale';
 
 function defaultCheckin(): string {
   const d = new Date();
@@ -33,21 +35,41 @@ function defaultCheckout(): string {
   return d.toISOString().slice(0, 10);
 }
 
-const SORT_OPTIONS = [
-  { key: '', label: 'Sort' },
-  { key: 'price_asc', label: 'Price' },
-  { key: 'rating', label: 'Rating' },
-] as const;
-
 const PAGE_SIZE = 20;
 
-function errorToMessage(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  return 'Error searching properties';
-}
-
 function SearchPageContent() {
+  const { t, i18n } = useTranslation();
   const params = useSearchParams();
+
+  const sortOptions = useMemo(
+    () =>
+      [
+        { key: '', label: t('searchPage.sort') },
+        { key: 'price_asc', label: t('searchPage.price') },
+        { key: 'rating', label: t('searchPage.rating') },
+      ] as const,
+    [t],
+  );
+
+  const amenityOptions: AmenitySummary[] = useMemo(
+    () => [
+      { code: 'wifi', name: t('searchAmenities.wifi') },
+      { code: 'kitchen', name: t('searchAmenities.kitchen') },
+      { code: 'pool', name: t('searchAmenities.pool') },
+      { code: 'air_conditioning', name: t('searchAmenities.air_conditioning') },
+      { code: 'breakfast', name: t('searchAmenities.breakfast') },
+      { code: 'parking', name: t('searchAmenities.parking') },
+    ],
+    [t],
+  );
+
+  const errorToMessage = useCallback(
+    (err: unknown): string => {
+      if (err instanceof Error) return err.message;
+      return t('searchPage.errorGeneric');
+    },
+    [t],
+  );
 
   // Parse initial city from URL params
   const initialCity = useMemo((): CityOut | null => {
@@ -79,15 +101,6 @@ function SearchPageContent() {
   /** Skips one catalog refetch when loadSearch was already invoked (initial load or search button). */
   const suppressCatalogRefetchRef = useRef(false);
 
-  const amenityOptions: AmenitySummary[] = [
-    { code: 'wifi', name: 'Wifi' },
-    { code: 'kitchen', name: 'Kitchen' },
-    { code: 'pool', name: 'Pool' },
-    { code: 'air_conditioning', name: 'Air conditioning' },
-    { code: 'breakfast', name: 'Breakfast' },
-    { code: 'parking', name: 'Parking' },
-  ];
-
   const loadFeatured = useCallback(async () => {
     setCatalogMode(false);
     setLoading(true);
@@ -102,7 +115,7 @@ function SearchPageContent() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [errorToMessage]);
 
   const loadSearch = useCallback(async (
     searchCityId: string,
@@ -136,7 +149,7 @@ function SearchPageContent() {
     } finally {
       setLoading(false);
     }
-  }, [minPrice, maxPrice, selectedAmenities, sortBy, page]);
+  }, [minPrice, maxPrice, selectedAmenities, sortBy, page, errorToMessage]);
 
   // Auto-search from URL params on first load
   useEffect(() => {
@@ -253,10 +266,12 @@ function SearchPageContent() {
     setPage(1);
   };
 
+  const dateLocale = dateFormattingLocale(i18n.language);
+
   const formatDateRange = () => {
     const fmt = (d: string) => {
       const date = new Date(d + 'T00:00:00');
-      return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+      return date.toLocaleDateString(dateLocale, { month: 'short', day: 'numeric' });
     };
     return `${fmt(checkin)} - ${fmt(checkout)}`;
   };
@@ -265,10 +280,10 @@ function SearchPageContent() {
     if (!gridData || gridData.items.length > 0) return '';
     const backendMsg = gridData.message?.trim();
     if (backendMsg) return backendMsg;
-    if (catalogMode && cityId) return 'No properties found for the selected destination and dates.';
-    if (featuredRaw.length === 0) return 'No featured stays available right now.';
-    return 'No properties match the selected filters.';
-  }, [gridData, cityId, catalogMode, featuredRaw.length]);
+    if (catalogMode && cityId) return t('searchPage.emptyCatalog');
+    if (featuredRaw.length === 0) return t('searchPage.emptyFeatured');
+    return t('searchPage.emptyFilters');
+  }, [gridData, cityId, catalogMode, featuredRaw.length, t]);
 
   return (
     <Box sx={{ minHeight: '100vh', bgcolor: 'grey.50' }}>
@@ -303,20 +318,19 @@ function SearchPageContent() {
       >
         <Box>
           <Typography variant="h5" fontWeight={700}>
-            {catalogMode && cityId && cityLabel ? `Stays in ${cityLabel}` : 'All stays'}
+            {catalogMode && cityId && cityLabel
+              ? t('searchPage.staysIn', { city: cityLabel })
+              : t('searchPage.allStays')}
           </Typography>
           {gridData && (
             <>
               <Typography variant="body2" color="text.secondary" sx={{ mt: 0.25 }}>
-                {gridData.total} place{gridData.total !== 1 ? 's' : ''} found · {formatDateRange()}
-                {catalogMode
-                  ? ` · at least ${guests} guest${guests !== 1 ? 's' : ''}`
-                  : ' · browse popular destinations'}
+                {t('searchPage.placesFound', { count: gridData.total })} · {formatDateRange()} ·{' '}
+                {catalogMode ? t('searchPage.guestTail', { count: guests }) : t('searchPage.browseTail')}
               </Typography>
               {catalogMode && (
                 <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
-                  Listings match your dates and minimum guest count in this destination. Per-room capacity is on
-                  each property detail page.
+                  {t('searchPage.catalogHint')}
                 </Typography>
               )}
             </>
@@ -324,7 +338,7 @@ function SearchPageContent() {
         </Box>
 
         <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-          {SORT_OPTIONS.map((opt) => (
+          {sortOptions.map((opt) => (
             <Chip
               key={opt.label}
               label={`${opt.label}${sortBy === opt.key && opt.key ? ' \u2193' : ''}`}

--- a/frontend/travel-hub/components/home/HeroSection.tsx
+++ b/frontend/travel-hub/components/home/HeroSection.tsx
@@ -1,5 +1,8 @@
+'use client';
+
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import { useTranslation } from 'react-i18next';
 
 import SearchBar from '@/components/search/SearchBar';
 import type { CityOut } from '@/app/lib/types/catalog';
@@ -23,6 +26,7 @@ export default function HeroSection({
   onGuestsChange,
   onSearch,
 }: HeroSectionProps) {
+  const { t } = useTranslation();
   return (
     <Box sx={{ bgcolor: 'white', py: { xs: 4, md: 8 }, textAlign: 'center' }}>
       <Box sx={{ maxWidth: 1280, mx: 'auto', px: { xs: 2, md: 4 } }}>
@@ -37,7 +41,7 @@ export default function HeroSection({
             mb: 2,
           }}
         >
-          Find your next stay
+          {t('hero.title')}
         </Typography>
 
         <Typography
@@ -50,7 +54,7 @@ export default function HeroSection({
             mb: 5,
           }}
         >
-          Unlock exclusive deals on your favorite hotels, homes, and more in Latin America.
+          {t('hero.subtitle')}
         </Typography>
 
         <Box sx={{ maxWidth: 900, mx: 'auto' }}>

--- a/frontend/travel-hub/components/home/NewsletterSection.tsx
+++ b/frontend/travel-hub/components/home/NewsletterSection.tsx
@@ -8,8 +8,10 @@ import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import FlightIcon from '@mui/icons-material/Flight';
 import LocalOfferIcon from '@mui/icons-material/LocalOffer';
+import { useTranslation } from 'react-i18next';
 
 export default function NewsletterSection() {
+  const { t } = useTranslation();
   const [email, setEmail] = useState('');
 
   return (
@@ -28,16 +30,15 @@ export default function NewsletterSection() {
       {/* Left content */}
       <Box sx={{ flex: 1 }}>
         <Typography variant="h2" sx={{ fontWeight: 700, fontSize: '1.875rem', color: 'grey.900', mb: 2 }}>
-          Plan your dream getaway today
+          {t('newsletter.title')}
         </Typography>
         <Typography sx={{ fontSize: '1rem', color: 'grey.500', mb: 2 }}>
-          Join thousands of travelers finding the best deals in Latin America. Sign up for our
-          newsletter to get exclusive offers.
+          {t('newsletter.body')}
         </Typography>
 
         <Box sx={{ display: 'flex', gap: 1.5, pt: 1, flexDirection: { xs: 'column', sm: 'row' }, alignItems: 'stretch' }}>
           <TextField
-            placeholder="Your email address"
+            placeholder={t('newsletter.emailPlaceholder')}
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             sx={{
@@ -63,7 +64,7 @@ export default function NewsletterSection() {
               '&:hover': { bgcolor: '#0284C7' },
             }}
           >
-            Subscribe
+            {t('newsletter.subscribe')}
           </Button>
         </Box>
       </Box>

--- a/frontend/travel-hub/components/home/PopularDestinations.tsx
+++ b/frontend/travel-hub/components/home/PopularDestinations.tsx
@@ -7,6 +7,7 @@ import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
+import { useTranslation } from 'react-i18next';
 
 import { getFeaturedDestinations } from '@/app/lib/api/catalog';
 import type { FeaturedDestination } from '@/app/lib/types/catalog';
@@ -18,6 +19,7 @@ interface PopularDestinationsProps {
 }
 
 export default function PopularDestinations({ checkin, checkout, guests }: PopularDestinationsProps) {
+  const { t } = useTranslation();
   const [destinations, setDestinations] = useState<FeaturedDestination[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -47,10 +49,10 @@ export default function PopularDestinations({ checkin, checkout, guests }: Popul
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', mb: 3 }}>
         <Box>
           <Typography variant="h2" sx={{ fontWeight: 700, fontSize: '1.5rem', color: 'grey.900' }}>
-            Popular Destinations
+            {t('popular.title')}
           </Typography>
           <Typography sx={{ fontSize: '1rem', color: 'grey.500', mt: 0.5 }}>
-            Trending places for travelers like you
+            {t('popular.subtitle')}
           </Typography>
         </Box>
         <Typography
@@ -64,7 +66,7 @@ export default function PopularDestinations({ checkin, checkout, guests }: Popul
             '&:hover': { textDecoration: 'underline' },
           }}
         >
-          See all
+          {t('popular.seeAll')}
         </Typography>
       </Box>
 
@@ -75,7 +77,7 @@ export default function PopularDestinations({ checkin, checkout, guests }: Popul
         </Box>
       ) : destinations.length === 0 ? (
         <Typography sx={{ color: 'grey.500', textAlign: 'center', py: 6 }}>
-          No destinations available right now.
+          {t('popular.empty')}
         </Typography>
       ) : (
         <Box

--- a/frontend/travel-hub/components/home/RecommendedSection.tsx
+++ b/frontend/travel-hub/components/home/RecommendedSection.tsx
@@ -8,11 +8,13 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
 import StarIcon from '@mui/icons-material/Star';
+import { useTranslation } from 'react-i18next';
 
 import { getFeaturedProperties } from '@/app/lib/api/catalog';
 import type { PropertySummary } from '@/app/lib/types/catalog';
 
 function PropertyCard({ property }: { property: PropertySummary }) {
+  const { t } = useTranslation();
   return (
     <Box
       component={NextLink}
@@ -50,7 +52,7 @@ function PropertyCard({ property }: { property: PropertySummary }) {
             justifyContent: 'center',
           }}
         >
-          <Typography sx={{ color: 'grey.400', fontSize: '0.875rem' }}>No image</Typography>
+          <Typography sx={{ color: 'grey.400', fontSize: '0.875rem' }}>{t('recommended.noImage')}</Typography>
         </Box>
       )}
 
@@ -136,7 +138,7 @@ function PropertyCard({ property }: { property: PropertySummary }) {
             <Typography sx={{ fontWeight: 700, fontSize: '1.5rem', color: '#0EA5E9' }}>
               ${property.min_price.toLocaleString()}
             </Typography>
-            <Typography sx={{ fontSize: '0.75rem', color: 'grey.500' }}>/ night</Typography>
+            <Typography sx={{ fontSize: '0.75rem', color: 'grey.500' }}>{t('recommended.perNight')}</Typography>
           </Box>
         )}
       </Box>
@@ -145,6 +147,7 @@ function PropertyCard({ property }: { property: PropertySummary }) {
 }
 
 export default function RecommendedSection() {
+  const { t } = useTranslation();
   const [properties, setProperties] = useState<PropertySummary[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -159,10 +162,10 @@ export default function RecommendedSection() {
     <Box>
       <Box sx={{ mb: 3 }}>
         <Typography variant="h2" sx={{ fontWeight: 700, fontSize: '1.5rem', color: 'grey.900' }}>
-          Recommended for You
+          {t('recommended.title')}
         </Typography>
         <Typography sx={{ fontSize: '1rem', color: 'grey.500', mt: 0.5 }}>
-          Properties based on your recent activity
+          {t('recommended.subtitle')}
         </Typography>
       </Box>
 
@@ -172,7 +175,7 @@ export default function RecommendedSection() {
         </Box>
       ) : properties.length === 0 ? (
         <Typography sx={{ color: 'grey.500', textAlign: 'center', py: 6 }}>
-          No properties available right now.
+          {t('recommended.empty')}
         </Typography>
       ) : (
         <Box

--- a/frontend/travel-hub/components/i18n/DocumentLang.tsx
+++ b/frontend/travel-hub/components/i18n/DocumentLang.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export function DocumentLang() {
+  const { i18n } = useTranslation();
+  useEffect(() => {
+    document.documentElement.lang = i18n.language;
+  }, [i18n.language]);
+  return null;
+}

--- a/frontend/travel-hub/components/i18n/I18nProvider.tsx
+++ b/frontend/travel-hub/components/i18n/I18nProvider.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import { I18nextProvider } from 'react-i18next';
+
+import i18n from '@/lib/i18n/client';
+
+export function I18nProvider({ children }: { children: React.ReactNode }) {
+  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
+}

--- a/frontend/travel-hub/components/i18n/LanguageSync.tsx
+++ b/frontend/travel-hub/components/i18n/LanguageSync.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+import i18n from '@/lib/i18n/client';
+import { defaultLocale } from '@/lib/i18n/settings';
+
+const STORAGE_KEY = 'i18nextLng';
+
+function normalizeStored(raw: string | null): 'en-US' | 'es-CO' | null {
+  if (!raw) return null;
+  if (raw === 'en-US' || raw === 'es-CO') return raw;
+  const base = raw.split('-')[0]?.toLowerCase();
+  if (base === 'es') return 'es-CO';
+  return defaultLocale;
+}
+
+/**
+ * Applies `localStorage` or `navigator` language after hydration so it never diverges from SSR output.
+ */
+export function LanguageSync() {
+  const ran = useRef(false);
+
+  useEffect(() => {
+    if (ran.current) return;
+    ran.current = true;
+
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      const stored = normalizeStored(raw);
+      if (stored && stored !== i18n.language) {
+        void i18n.changeLanguage(stored);
+        return;
+      }
+      if (!raw && typeof navigator !== 'undefined' && navigator.language.toLowerCase().startsWith('es')) {
+        void i18n.changeLanguage('es-CO');
+      }
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  return null;
+}

--- a/frontend/travel-hub/components/i18n/TranslatedMeta.tsx
+++ b/frontend/travel-hub/components/i18n/TranslatedMeta.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export function TranslatedMeta() {
+  const { t, i18n } = useTranslation();
+  useEffect(() => {
+    document.title = t('meta.title');
+    const meta = document.querySelector('meta[name="description"]');
+    if (meta) meta.setAttribute('content', t('meta.description'));
+  }, [t, i18n.language]);
+  return null;
+}

--- a/frontend/travel-hub/components/layout/Footer.tsx
+++ b/frontend/travel-hub/components/layout/Footer.tsx
@@ -1,27 +1,15 @@
+'use client';
+
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import FacebookIcon from '@mui/icons-material/Facebook';
+import { useTranslation } from 'react-i18next';
 
-const FOOTER_SECTIONS = [
-  {
-    title: 'Support',
-    links: ['Help Center', 'Safety information', 'Cancellation options', 'Report a concern'],
-  },
-  {
-    title: 'Community',
-    links: ['TravelHub Blog', 'Community Forum', 'Travel Guides'],
-  },
-  {
-    title: 'Hosting',
-    links: ['List your property', 'Host resources', 'Community forum'],
-  },
-  {
-    title: 'About',
-    links: ['Newsroom', 'Learn about new features', 'Careers', 'Investors'],
-  },
-];
+const FOOTER_KEYS = ['support', 'community', 'hosting', 'about'] as const;
 
 export default function Footer() {
+  const { t } = useTranslation();
+
   return (
     <Box
       component="footer"
@@ -33,7 +21,6 @@ export default function Footer() {
       }}
     >
       <Box sx={{ maxWidth: 1280, mx: 'auto', px: { xs: 2, md: 4 } }}>
-        {/* Link columns */}
         <Box
           sx={{
             display: 'grid',
@@ -41,8 +28,8 @@ export default function Footer() {
             gap: 4,
           }}
         >
-          {FOOTER_SECTIONS.map((section) => (
-            <Box key={section.title}>
+          {FOOTER_KEYS.map((key) => (
+            <Box key={key}>
               <Typography
                 sx={{
                   fontWeight: 700,
@@ -52,10 +39,10 @@ export default function Footer() {
                   mb: 2,
                 }}
               >
-                {section.title}
+                {t(`footer.${key}.title`)}
               </Typography>
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-                {section.links.map((link) => (
+                {(t(`footer.${key}.links`, { returnObjects: true }) as string[]).map((link) => (
                   <Typography
                     key={link}
                     component="a"
@@ -76,7 +63,6 @@ export default function Footer() {
           ))}
         </Box>
 
-        {/* Bottom bar */}
         <Box
           sx={{
             borderTop: '1px solid #E5E7EB',
@@ -89,17 +75,15 @@ export default function Footer() {
             gap: 2,
           }}
         >
-          {/* Left: logo + copyright */}
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <img src="/icon.svg" alt="TravelHub" width={17} height={17} />
+            <img src="/icon.svg" alt={t('brand.name')} width={17} height={17} />
             <Typography sx={{ fontSize: 14, color: '#64748B', lineHeight: '20px' }}>
-              &copy; 2026 TravelHub, Inc.
+              {t('footer.copyright')}
             </Typography>
           </Box>
 
-          {/* Center: legal links */}
           <Box sx={{ display: 'flex', gap: 3 }}>
-            {['Privacy', 'Terms', 'Sitemap'].map((text) => (
+            {(t('footer.legal', { returnObjects: true }) as string[]).map((text) => (
               <Typography
                 key={text}
                 component="a"
@@ -117,7 +101,6 @@ export default function Footer() {
             ))}
           </Box>
 
-          {/* Right: social icons */}
           <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
             <Box component="a" href="#" sx={{ color: '#64748B', display: 'flex', '&:hover': { color: '#0EA5E9' } }}>
               <FacebookIcon sx={{ fontSize: 20 }} />

--- a/frontend/travel-hub/components/layout/Navbar.tsx
+++ b/frontend/travel-hub/components/layout/Navbar.tsx
@@ -16,17 +16,20 @@ import NotificationsNoneIcon from '@mui/icons-material/NotificationsNone';
 import LanguageIcon from '@mui/icons-material/Language';
 import AccountCircleOutlinedIcon from '@mui/icons-material/AccountCircleOutlined';
 import LogoutIcon from '@mui/icons-material/Logout';
+import { useTranslation } from 'react-i18next';
 
 import { getMe } from '@/app/lib/api/auth';
+import { defaultLocale } from '@/lib/i18n/settings';
 
 const navLinkActive = '#0EA5E9';
 
 export default function Navbar() {
   const pathname = usePathname();
   const router = useRouter();
+  const { t, i18n } = useTranslation();
   const [user, setUser] = useState<{ email: string; role: string } | null>(null);
-  const [lang, setLang] = useState<'EN' | 'ES'>('EN');
   const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
+  const langLabel = i18n.language.startsWith('es') ? 'ES' : 'EN';
 
   useEffect(() => {
     getMe().then(setUser).catch(() => setUser(null));
@@ -54,9 +57,9 @@ export default function Navbar() {
             href="/"
             sx={{ display: 'flex', alignItems: 'center', gap: 1, textDecoration: 'none' }}
           >
-            <Box component="img" src="/icon.svg" alt="TravelHub" sx={{ width: 26, height: 25 }} />
+            <Box component="img" src="/icon.svg" alt={t('brand.name')} sx={{ width: 26, height: 25 }} />
             <Typography sx={{ fontWeight: 700, fontSize: '1.25rem', color: 'grey.900', letterSpacing: '-0.025em' }}>
-              TravelHub
+              {t('brand.name')}
             </Typography>
           </Box>
 
@@ -73,7 +76,7 @@ export default function Navbar() {
               '&:hover': { color: navLinkActive },
             }}
           >
-            Explore
+            {t('nav.explore')}
           </Typography>
 
           {user && (
@@ -90,7 +93,7 @@ export default function Navbar() {
                 '&:hover': { color: navLinkActive },
               }}
             >
-              My Trips
+              {t('nav.myTrips')}
             </Typography>
           )}
         </Box>
@@ -100,12 +103,14 @@ export default function Navbar() {
         {/* Right section */}
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <IconButton
-            onClick={() => setLang((prev) => (prev === 'EN' ? 'ES' : 'EN'))}
+            onClick={() =>
+              void i18n.changeLanguage(i18n.language.startsWith('es') ? defaultLocale : 'es-CO')
+            }
             sx={{ color: 'grey.500', borderRadius: '8px', gap: 0.5, fontSize: '0.8rem' }}
           >
             <LanguageIcon sx={{ fontSize: 20 }} />
             <Typography component="span" sx={{ fontSize: '0.75rem', fontWeight: 500, color: 'grey.600' }}>
-              {lang}
+              {langLabel}
             </Typography>
           </IconButton>
 
@@ -151,7 +156,7 @@ export default function Navbar() {
                   <ListItemIcon>
                     <LogoutIcon sx={{ fontSize: 18, color: 'grey.500' }} />
                   </ListItemIcon>
-                  Log out
+                  {t('nav.logOut')}
                 </MenuItem>
               </Menu>
             </>
@@ -167,7 +172,7 @@ export default function Navbar() {
                 '&:hover': { color: '#0EA5E9' },
               }}
             >
-              Log in
+              {t('nav.logIn')}
             </Typography>
           )}
         </Box>

--- a/frontend/travel-hub/components/search/SearchBar.tsx
+++ b/frontend/travel-hub/components/search/SearchBar.tsx
@@ -18,8 +18,10 @@ import GroupOutlinedIcon from '@mui/icons-material/GroupOutlined';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { useTranslation } from 'react-i18next';
 
 import { searchCities } from '@/app/lib/api/catalog';
+import { dateFormattingLocale } from '@/lib/i18n/dateLocale';
 import type { CityOut } from '@/app/lib/types/catalog';
 
 export interface SearchBarProps {
@@ -48,10 +50,10 @@ function toIso(date: Date | null): string | null {
   return date.toISOString().slice(0, 10);
 }
 
-function formatDateRange(checkin: string, checkout: string): string {
+function formatDateRange(checkin: string, checkout: string, locale: string): string {
   const fmt = (d: string) => {
     const date = new Date(d + 'T00:00:00');
-    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    return date.toLocaleDateString(locale, { month: 'short', day: 'numeric' });
   };
   return `${fmt(checkin)} - ${fmt(checkout)}`;
 }
@@ -93,6 +95,8 @@ export default function SearchBar({
   initialCity = null,
   variant = 'button',
 }: SearchBarProps) {
+  const { t, i18n } = useTranslation();
+  const dateLocale = dateFormattingLocale(i18n.language);
   const [selected, setSelected] = useState<CityOut | null>(initialCity);
   const [inputValue, setInputValue] = useState(initialCity ? formatCity(initialCity) : '');
   const [options, setOptions] = useState<CityOut[]>([]);
@@ -176,7 +180,7 @@ export default function SearchBar({
         <Box sx={{ flex: 1.2, display: 'flex', alignItems: 'center', gap: 1.5, px: 2, py: 1.5, minWidth: 0 }}>
           <LocationOnOutlinedIcon sx={{ color: '#0EA5E9', fontSize: '1.5rem', flexShrink: 0 }} />
           <Box sx={{ flex: 1, minWidth: 0 }}>
-            <Typography sx={labelSx}>Where</Typography>
+            <Typography sx={labelSx}>{t('search.where')}</Typography>
             <Autocomplete
               options={options}
               loading={loadingCities}
@@ -190,12 +194,12 @@ export default function SearchBar({
               }}
               filterOptions={(x) => x}
               isOptionEqualToValue={(a, b) => a.id === b.id}
-              noOptionsText={inputValue.trim().length < 2 ? 'Type at least 2 letters' : 'No cities found'}
+              noOptionsText={inputValue.trim().length < 2 ? t('search.typeTwoChars') : t('search.noCities')}
               fullWidth
               renderInput={(params) => (
                 <TextField
                   {...params}
-                  placeholder="Search destination"
+                  placeholder={t('search.searchDestination')}
                   variant="standard"
                   slotProps={{
                     input: {
@@ -231,8 +235,8 @@ export default function SearchBar({
         >
           <CalendarTodayOutlinedIcon sx={{ color: '#0EA5E9', fontSize: '1.5rem', flexShrink: 0 }} />
           <Box>
-            <Typography sx={labelSx}>When</Typography>
-            <Typography sx={valueSx}>{formatDateRange(checkin, checkout)}</Typography>
+            <Typography sx={labelSx}>{t('search.when')}</Typography>
+            <Typography sx={valueSx}>{formatDateRange(checkin, checkout, dateLocale)}</Typography>
           </Box>
         </Box>
 
@@ -244,17 +248,17 @@ export default function SearchBar({
           transformOrigin={{ vertical: 'top', horizontal: 'left' }}
           slotProps={{ paper: { sx: { borderRadius: 3, p: 3, mt: 1, display: 'flex', flexDirection: 'column', gap: 2 } } }}
         >
-          <Typography sx={{ fontWeight: 600, color: 'grey.700' }}>Select dates</Typography>
+          <Typography sx={{ fontWeight: 600, color: 'grey.700' }}>{t('search.selectDates')}</Typography>
           <Box sx={{ display: 'flex', gap: 2 }}>
             <DatePicker
-              label="Check-in"
+              label={t('search.checkIn')}
               value={toDate(checkin)}
               onChange={(d) => { const iso = toIso(d); if (iso) onCheckinChange(iso); }}
               disablePast
               slotProps={{ textField: { size: 'small' } }}
             />
             <DatePicker
-              label="Check-out"
+              label={t('search.checkOut')}
               value={toDate(checkout)}
               onChange={(d) => { const iso = toIso(d); if (iso) onCheckoutChange(iso); }}
               minDate={toDate(checkin)}
@@ -276,10 +280,8 @@ export default function SearchBar({
         >
           <GroupOutlinedIcon sx={{ color: '#0EA5E9', fontSize: '1.5rem', flexShrink: 0 }} />
           <Box>
-            <Typography sx={labelSx}>Who</Typography>
-            <Typography sx={valueSx}>
-              {guests} guest{guests !== 1 ? 's' : ''}
-            </Typography>
+            <Typography sx={labelSx}>{t('search.who')}</Typography>
+            <Typography sx={valueSx}>{t('search.guestsCount', { count: guests })}</Typography>
           </Box>
         </Box>
 
@@ -291,7 +293,7 @@ export default function SearchBar({
           transformOrigin={{ vertical: 'top', horizontal: 'center' }}
           slotProps={{ paper: { sx: { borderRadius: 3, p: 3, mt: 1 } } }}
         >
-          <Typography sx={{ fontWeight: 600, color: 'grey.700', mb: 1.5 }}>Guests</Typography>
+          <Typography sx={{ fontWeight: 600, color: 'grey.700', mb: 1.5 }}>{t('search.guests')}</Typography>
           <TextField
             type="text"
             inputMode="numeric"
@@ -305,7 +307,7 @@ export default function SearchBar({
             placeholder="1"
             size="small"
             sx={{ minWidth: 120 }}
-            helperText="Minimum 1 guest"
+            helperText={t('search.guestsMinHelper')}
           />
         </Popover>
 
@@ -330,7 +332,7 @@ export default function SearchBar({
               '&.Mui-disabled': { bgcolor: 'grey.300', color: 'white' },
             }}
           >
-            Search
+            {t('search.search')}
           </Button>
         ) : (
           <IconButton

--- a/frontend/travel-hub/components/traveler/AmenityFilter.tsx
+++ b/frontend/travel-hub/components/traveler/AmenityFilter.tsx
@@ -8,6 +8,7 @@ import Checkbox from '@mui/material/Checkbox';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import FormGroup from '@mui/material/FormGroup';
 import Typography from '@mui/material/Typography';
+import { useTranslation } from 'react-i18next';
 
 import type { AmenitySummary } from '@/app/lib/types/catalog';
 
@@ -18,6 +19,7 @@ interface AmenityFilterProps {
 }
 
 export default function AmenityFilter({ amenities, selected, onChange }: AmenityFilterProps) {
+  const { t } = useTranslation();
   const [showAll, setShowAll] = useState(false);
   const visible = showAll ? amenities : amenities.slice(0, 4);
 
@@ -53,7 +55,7 @@ export default function AmenityFilter({ amenities, selected, onChange }: Amenity
       </FormGroup>
       {amenities.length > 4 && (
         <Button size="small" onClick={() => setShowAll(!showAll)} sx={{ textTransform: 'none', mt: 0.5 }}>
-          {showAll ? 'Show less' : 'Show more'}
+          {showAll ? t('amenityFilter.showLess') : t('amenityFilter.showMore')}
         </Button>
       )}
     </Box>

--- a/frontend/travel-hub/components/traveler/PriceRangeFilter.tsx
+++ b/frontend/travel-hub/components/traveler/PriceRangeFilter.tsx
@@ -7,6 +7,7 @@ import InputAdornment from '@mui/material/InputAdornment';
 import Slider from '@mui/material/Slider';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import { useTranslation } from 'react-i18next';
 
 interface PriceRangeFilterProps {
   minPrice?: number;
@@ -15,6 +16,7 @@ interface PriceRangeFilterProps {
 }
 
 export default function PriceRangeFilter({ minPrice, maxPrice, onApply }: PriceRangeFilterProps) {
+  const { t } = useTranslation();
   const [range, setRange] = useState<[number, number]>([minPrice ?? 0, maxPrice ?? 1000]);
   const [error, setError] = useState<string | null>(null);
 
@@ -48,7 +50,7 @@ export default function PriceRangeFilter({ minPrice, maxPrice, onApply }: PriceR
 
   const handleBlur = () => {
     if (range[0] > range[1]) {
-      setError('Min cannot be greater than max');
+      setError(t('priceRange.minGreaterThanMax'));
       return;
     }
     setError(null);
@@ -58,10 +60,10 @@ export default function PriceRangeFilter({ minPrice, maxPrice, onApply }: PriceR
   return (
     <Box>
       <Typography variant="subtitle1" fontWeight={600} gutterBottom>
-        Price range
+        {t('priceRange.title')}
       </Typography>
       <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 2 }}>
-        Nightly prices before fees and taxes
+        {t('priceRange.caption')}
       </Typography>
       <Slider
         value={range}
@@ -86,7 +88,7 @@ export default function PriceRangeFilter({ minPrice, maxPrice, onApply }: PriceR
       />
       <Box sx={{ display: 'flex', gap: 2, mt: 1 }}>
         <TextField
-          label="Min"
+          label={t('priceRange.min')}
           type="number"
           size="small"
           value={range[0]}
@@ -101,7 +103,7 @@ export default function PriceRangeFilter({ minPrice, maxPrice, onApply }: PriceR
           sx={{ flex: 1 }}
         />
         <TextField
-          label="Max"
+          label={t('priceRange.max')}
           type="number"
           size="small"
           value={range[1]}

--- a/frontend/travel-hub/components/traveler/PropertyCard.tsx
+++ b/frontend/travel-hub/components/traveler/PropertyCard.tsx
@@ -10,6 +10,8 @@ import Chip from '@mui/material/Chip';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
 import StarIcon from '@mui/icons-material/Star';
 import Typography from '@mui/material/Typography';
+import type { TFunction } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import type { PropertySummary } from '@/app/lib/types/catalog';
 
@@ -17,12 +19,13 @@ interface PropertyCardProps {
   property: PropertySummary;
 }
 
-function formatReviewCount(count: number): string {
-  if (count >= 1000) return `${(count / 1000).toFixed(1)}k reviews`;
-  return `${count} reviews`;
+function formatReviewCount(count: number, t: TFunction): string {
+  if (count >= 1000) return t('propertyCard.reviewsShort', { count: (count / 1000).toFixed(1) });
+  return t('propertyCard.reviews', { count });
 }
 
 export default function PropertyCard({ property }: PropertyCardProps) {
+  const { t } = useTranslation();
   return (
     <NextLink href={`/traveler/hotel?id=${property.id}`} style={{ textDecoration: 'none', display: 'block', height: '100%' }}>
     <Card
@@ -56,7 +59,7 @@ export default function PropertyCard({ property }: PropertyCardProps) {
             justifyContent: 'center',
           }}
         >
-          <Typography color="text.secondary">No image</Typography>
+          <Typography color="text.secondary">{t('propertyCard.noImage')}</Typography>
         </Box>
       )}
 
@@ -93,7 +96,7 @@ export default function PropertyCard({ property }: PropertyCardProps) {
                 }}
               />
               <Typography variant="caption" sx={{ display: 'block', color: 'grey.500', mt: 0.25 }}>
-                {formatReviewCount(property.review_count)}
+                {formatReviewCount(property.review_count, t)}
               </Typography>
             </Box>
           )}
@@ -129,7 +132,7 @@ export default function PropertyCard({ property }: PropertyCardProps) {
               ${property.min_price.toLocaleString()}
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              / night
+              {t('propertyCard.perNight')}
             </Typography>
           </Box>
         )}

--- a/frontend/travel-hub/lib/i18n/client.ts
+++ b/frontend/travel-hub/lib/i18n/client.ts
@@ -1,0 +1,42 @@
+import i18n from 'i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+import { initReactI18next } from 'react-i18next';
+
+import { defaultLocale, locales } from '@/lib/i18n/settings';
+
+import enUS from '@/lib/i18n/locales/en-US/common.json';
+import esCO from '@/lib/i18n/locales/es-CO/common.json';
+
+void i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources: {
+      'en-US': { common: enUS },
+      'es-CO': { common: esCO },
+    },
+    fallbackLng: defaultLocale,
+    supportedLngs: [...locales],
+    defaultNS: 'common',
+    ns: ['common'],
+    detection: {
+      order: ['localStorage', 'navigator', 'htmlTag'],
+      caches: ['localStorage'],
+    },
+    interpolation: { escapeValue: false },
+    react: { useSuspense: false },
+  });
+
+function normalizeToSupported(lng: string): string {
+  const base = lng.split('-')[0]?.toLowerCase() ?? 'en';
+  if (base === 'es') return 'es-CO';
+  return defaultLocale;
+}
+
+i18n.on('initialized', () => {
+  const lng = i18n.language;
+  const next = normalizeToSupported(lng);
+  if (lng !== next) void i18n.changeLanguage(next);
+});
+
+export default i18n;

--- a/frontend/travel-hub/lib/i18n/client.ts
+++ b/frontend/travel-hub/lib/i18n/client.ts
@@ -1,5 +1,4 @@
 import i18n from 'i18next';
-import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 
 import { defaultLocale, locales } from '@/lib/i18n/settings';
@@ -7,36 +6,34 @@ import { defaultLocale, locales } from '@/lib/i18n/settings';
 import enUS from '@/lib/i18n/locales/en-US/common.json';
 import esCO from '@/lib/i18n/locales/es-CO/common.json';
 
-void i18n
-  .use(LanguageDetector)
-  .use(initReactI18next)
-  .init({
-    resources: {
-      'en-US': { common: enUS },
-      'es-CO': { common: esCO },
-    },
-    fallbackLng: defaultLocale,
-    supportedLngs: [...locales],
-    defaultNS: 'common',
-    ns: ['common'],
-    detection: {
-      order: ['localStorage', 'navigator', 'htmlTag'],
-      caches: ['localStorage'],
-    },
-    interpolation: { escapeValue: false },
-    react: { useSuspense: false },
-  });
+const STORAGE_KEY = 'i18nextLng';
 
-function normalizeToSupported(lng: string): string {
-  const base = lng.split('-')[0]?.toLowerCase() ?? 'en';
-  if (base === 'es') return 'es-CO';
-  return defaultLocale;
-}
-
-i18n.on('initialized', () => {
-  const lng = i18n.language;
-  const next = normalizeToSupported(lng);
-  if (lng !== next) void i18n.changeLanguage(next);
+/**
+ * Fixed initial language for SSR and the first client render so markup matches (avoids hydration errors).
+ * User preference is applied after mount in `LanguageSync`.
+ */
+void i18n.use(initReactI18next).init({
+  lng: defaultLocale,
+  fallbackLng: defaultLocale,
+  supportedLngs: [...locales],
+  resources: {
+    'en-US': { common: enUS },
+    'es-CO': { common: esCO },
+  },
+  defaultNS: 'common',
+  ns: ['common'],
+  interpolation: { escapeValue: false },
+  react: { useSuspense: false },
 });
+
+if (typeof window !== 'undefined') {
+  i18n.on('languageChanged', (lng) => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, lng);
+    } catch {
+      /* ignore */
+    }
+  });
+}
 
 export default i18n;

--- a/frontend/travel-hub/lib/i18n/dateLocale.ts
+++ b/frontend/travel-hub/lib/i18n/dateLocale.ts
@@ -1,0 +1,4 @@
+/** BCP 47 locale for `toLocaleDateString` / formatting, aligned with app locales. */
+export function dateFormattingLocale(i18nLanguage: string): string {
+  return i18nLanguage.startsWith('es') ? 'es-CO' : 'en-US';
+}

--- a/frontend/travel-hub/lib/i18n/locales/en-US/common.json
+++ b/frontend/travel-hub/lib/i18n/locales/en-US/common.json
@@ -1,0 +1,123 @@
+{
+  "meta": {
+    "title": "TravelHub — Find Your Next Stay",
+    "description": "Unlock exclusive deals on hotels, homes, and more across Latin America."
+  },
+  "brand": {
+    "name": "TravelHub"
+  },
+  "nav": {
+    "explore": "Explore",
+    "myTrips": "My Trips",
+    "logIn": "Log in",
+    "logOut": "Log out"
+  },
+  "hero": {
+    "title": "Find your next stay",
+    "subtitle": "Unlock exclusive deals on your favorite hotels, homes, and more in Latin America."
+  },
+  "search": {
+    "where": "Where",
+    "when": "When",
+    "who": "Who",
+    "searchDestination": "Search destination",
+    "typeTwoChars": "Type at least 2 letters",
+    "noCities": "No cities found",
+    "selectDates": "Select dates",
+    "checkIn": "Check-in",
+    "checkOut": "Check-out",
+    "guests": "Guests",
+    "guestsMinHelper": "Minimum 1 guest",
+    "search": "Search",
+    "guestsCount_one": "{{count}} guest",
+    "guestsCount_other": "{{count}} guests"
+  },
+  "popular": {
+    "title": "Popular Destinations",
+    "subtitle": "Trending places for travelers like you",
+    "seeAll": "See all",
+    "empty": "No destinations available right now."
+  },
+  "recommended": {
+    "title": "Recommended for You",
+    "subtitle": "Properties based on your recent activity",
+    "empty": "No properties available right now.",
+    "noImage": "No image",
+    "perNight": "/ night"
+  },
+  "newsletter": {
+    "title": "Plan your dream getaway today",
+    "body": "Join thousands of travelers finding the best deals in Latin America. Sign up for our newsletter to get exclusive offers.",
+    "emailPlaceholder": "Your email address",
+    "subscribe": "Subscribe"
+  },
+  "footer": {
+    "support": {
+      "title": "Support",
+      "links": [
+        "Help Center",
+        "Safety information",
+        "Cancellation options",
+        "Report a concern"
+      ]
+    },
+    "community": {
+      "title": "Community",
+      "links": ["TravelHub Blog", "Community Forum", "Travel Guides"]
+    },
+    "hosting": {
+      "title": "Hosting",
+      "links": ["List your property", "Host resources", "Community forum"]
+    },
+    "about": {
+      "title": "About",
+      "links": ["Newsroom", "Learn about new features", "Careers", "Investors"]
+    },
+    "copyright": "© 2026 TravelHub, Inc.",
+    "legal": ["Privacy", "Terms", "Sitemap"]
+  },
+  "priceRange": {
+    "title": "Price range",
+    "caption": "Nightly prices before fees and taxes",
+    "min": "Min",
+    "max": "Max",
+    "minGreaterThanMax": "Min cannot be greater than max"
+  },
+  "amenityFilter": {
+    "title": "Amenities",
+    "showMore": "Show more",
+    "showLess": "Show less"
+  },
+  "propertyCard": {
+    "noImage": "No image",
+    "perNight": "/ night",
+    "reviews_one": "{{count}} review",
+    "reviews_other": "{{count}} reviews",
+    "reviewsShort": "{{count}}k reviews"
+  },
+  "searchPage": {
+    "sort": "Sort",
+    "price": "Price",
+    "rating": "Rating",
+    "allStays": "All stays",
+    "staysIn": "Stays in {{city}}",
+    "placesFound_one": "{{count}} place found",
+    "placesFound_other": "{{count}} places found",
+    "guestTail_one": "at least {{count}} guest",
+    "guestTail_other": "at least {{count}} guests",
+    "browseTail": "browse popular destinations",
+    "catalogHint": "Listings match your dates and minimum guest count in this destination. Per-room capacity is on each property detail page.",
+    "errorGeneric": "Error searching properties",
+    "emptyCatalog": "No properties found for the selected destination and dates.",
+    "emptyFeatured": "No featured stays available right now.",
+    "emptyFilters": "No properties match the selected filters."
+  },
+  "searchAmenities": {
+    "wifi": "Wifi",
+    "kitchen": "Kitchen",
+    "pool": "Pool",
+    "air_conditioning": "Air conditioning",
+    "breakfast": "Breakfast",
+    "parking": "Parking"
+  }
+}

--- a/frontend/travel-hub/lib/i18n/locales/es-CO/common.json
+++ b/frontend/travel-hub/lib/i18n/locales/es-CO/common.json
@@ -1,0 +1,123 @@
+{
+  "meta": {
+    "title": "TravelHub — Encuentra tu próxima estadía",
+    "description": "Accede a ofertas exclusivas en hoteles, casas y más en América Latina."
+  },
+  "brand": {
+    "name": "TravelHub"
+  },
+  "nav": {
+    "explore": "Explorar",
+    "myTrips": "Mis viajes",
+    "logIn": "Iniciar sesión",
+    "logOut": "Cerrar sesión"
+  },
+  "hero": {
+    "title": "Encuentra tu próxima estadía",
+    "subtitle": "Desbloquea ofertas exclusivas en tus hoteles y alojamientos favoritos en América Latina."
+  },
+  "search": {
+    "where": "¿Dónde?",
+    "when": "¿Cuándo?",
+    "who": "¿Quiénes?",
+    "searchDestination": "Buscar destino",
+    "typeTwoChars": "Escribe al menos 2 letras",
+    "noCities": "No se encontraron ciudades",
+    "selectDates": "Seleccionar fechas",
+    "checkIn": "Entrada",
+    "checkOut": "Salida",
+    "guests": "Huéspedes",
+    "guestsMinHelper": "Mínimo 1 huésped",
+    "search": "Buscar",
+    "guestsCount_one": "{{count}} huésped",
+    "guestsCount_other": "{{count}} huéspedes"
+  },
+  "popular": {
+    "title": "Destinos populares",
+    "subtitle": "Lugares en tendencia para viajeros como tú",
+    "seeAll": "Ver todo",
+    "empty": "No hay destinos disponibles en este momento."
+  },
+  "recommended": {
+    "title": "Recomendado para ti",
+    "subtitle": "Propiedades según tu actividad reciente",
+    "empty": "No hay propiedades disponibles en este momento.",
+    "noImage": "Sin imagen",
+    "perNight": "/ noche"
+  },
+  "newsletter": {
+    "title": "Planifica tu escapada soñada hoy",
+    "body": "Únete a miles de viajeros que encuentran las mejores ofertas en América Latina. Suscríbete al boletín para recibir promociones exclusivas.",
+    "emailPlaceholder": "Tu correo electrónico",
+    "subscribe": "Suscribirme"
+  },
+  "footer": {
+    "support": {
+      "title": "Soporte",
+      "links": [
+        "Centro de ayuda",
+        "Información de seguridad",
+        "Opciones de cancelación",
+        "Reportar una preocupación"
+      ]
+    },
+    "community": {
+      "title": "Comunidad",
+      "links": ["Blog de TravelHub", "Foro de la comunidad", "Guías de viaje"]
+    },
+    "hosting": {
+      "title": "Anfitrión",
+      "links": ["Publica tu propiedad", "Recursos para anfitriones", "Foro de la comunidad"]
+    },
+    "about": {
+      "title": "Acerca de",
+      "links": ["Sala de prensa", "Novedades", "Empleo", "Inversionistas"]
+    },
+    "copyright": "© 2026 TravelHub, Inc.",
+    "legal": ["Privacidad", "Términos", "Mapa del sitio"]
+  },
+  "priceRange": {
+    "title": "Rango de precio",
+    "caption": "Precios por noche antes de impuestos y cargos",
+    "min": "Mín.",
+    "max": "Máx.",
+    "minGreaterThanMax": "El mínimo no puede ser mayor que el máximo"
+  },
+  "amenityFilter": {
+    "title": "Servicios",
+    "showMore": "Ver más",
+    "showLess": "Ver menos"
+  },
+  "propertyCard": {
+    "noImage": "Sin imagen",
+    "perNight": "/ noche",
+    "reviews_one": "{{count}} reseña",
+    "reviews_other": "{{count}} reseñas",
+    "reviewsShort": "{{count}}k reseñas"
+  },
+  "searchPage": {
+    "sort": "Ordenar",
+    "price": "Precio",
+    "rating": "Calificación",
+    "allStays": "Todos los alojamientos",
+    "staysIn": "Alojamientos en {{city}}",
+    "placesFound_one": "{{count}} lugar encontrado",
+    "placesFound_other": "{{count}} lugares encontrados",
+    "guestTail_one": "al menos {{count}} huésped",
+    "guestTail_other": "al menos {{count}} huéspedes",
+    "browseTail": "explora destinos populares",
+    "catalogHint": "Los resultados coinciden con tus fechas y el número mínimo de huéspedes en este destino. La capacidad por habitación está en la página de cada propiedad.",
+    "errorGeneric": "Error al buscar alojamientos",
+    "emptyCatalog": "No se encontraron alojamientos para el destino y las fechas seleccionadas.",
+    "emptyFeatured": "No hay estadías destacadas disponibles en este momento.",
+    "emptyFilters": "Ninguna propiedad coincide con los filtros seleccionados."
+  },
+  "searchAmenities": {
+    "wifi": "Wifi",
+    "kitchen": "Cocina",
+    "pool": "Piscina",
+    "air_conditioning": "Aire acondicionado",
+    "breakfast": "Desayuno",
+    "parking": "Parqueadero"
+  }
+}

--- a/frontend/travel-hub/lib/i18n/settings.ts
+++ b/frontend/travel-hub/lib/i18n/settings.ts
@@ -1,0 +1,8 @@
+export const defaultLocale = 'en-US' as const;
+export const locales = ['en-US', 'es-CO'] as const;
+
+export type AppLocale = (typeof locales)[number];
+
+export function isAppLocale(value: string): value is AppLocale {
+  return (locales as readonly string[]).includes(value);
+}

--- a/frontend/travel-hub/package.json
+++ b/frontend/travel-hub/package.json
@@ -22,7 +22,10 @@
     "@mui/material-nextjs": "^7.3.9",
     "@mui/x-date-pickers": "^8.27.2",
     "date-fns": "^4.1.0",
+    "i18next": "^25.0.0",
+    "i18next-browser-languagedetector": "^8.0.0",
     "next": "16.2.0",
+    "react-i18next": "^15.0.0",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },

--- a/frontend/travel-hub/package.json
+++ b/frontend/travel-hub/package.json
@@ -23,7 +23,6 @@
     "@mui/x-date-pickers": "^8.27.2",
     "date-fns": "^4.1.0",
     "i18next": "^25.0.0",
-    "i18next-browser-languagedetector": "^8.0.0",
     "next": "16.2.0",
     "react-i18next": "^15.0.0",
     "react": "19.2.4",

--- a/frontend/travel-hub/pnpm-lock.yaml
+++ b/frontend/travel-hub/pnpm-lock.yaml
@@ -32,6 +32,12 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      i18next:
+        specifier: ^25.0.0
+        version: 25.10.10(typescript@5.9.3)
+      i18next-browser-languagedetector:
+        specifier: ^8.0.0
+        version: 8.2.1
       next:
         specifier: 16.2.0
         version: 16.2.0(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -41,6 +47,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      react-i18next:
+        specifier: ^15.0.0
+        version: 15.7.4(i18next@25.10.10(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4
@@ -1887,10 +1896,24 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  html-parse-stringify@3.0.1:
+    resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
+
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  i18next-browser-languagedetector@8.2.1:
+    resolution: {integrity: sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==}
+
+  i18next@25.10.10:
+    resolution: {integrity: sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==}
+    peerDependencies:
+      typescript: ^5 || ^6
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2435,6 +2458,22 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
+  react-i18next@15.7.4:
+    resolution: {integrity: sha512-nyU8iKNrI5uDJch0z9+Y5XEr34b0wkyYj3Rp+tfbahxtlswxSCjcUL9H0nqXo9IR3/t5Y5PKIA3fx3MfUyR9Xw==}
+    peerDependencies:
+      i18next: '>= 23.4.0'
+      react: '>= 16.8.0'
+      react-dom: '*'
+      react-native: '*'
+      typescript: ^5
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+      typescript:
+        optional: true
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -2853,6 +2892,10 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  void-elements@3.1.0:
+    resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
+    engines: {node: '>=0.10.0'}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -4750,7 +4793,21 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  html-parse-stringify@3.0.1:
+    dependencies:
+      void-elements: 3.1.0
+
   husky@9.1.7: {}
+
+  i18next-browser-languagedetector@8.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+
+  i18next@25.10.10(typescript@5.9.3):
+    dependencies:
+      '@babel/runtime': 7.29.2
+    optionalDependencies:
+      typescript: 5.9.3
 
   ignore@5.3.2: {}
 
@@ -5281,6 +5338,16 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
+  react-i18next@15.7.4(i18next@25.10.10(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      html-parse-stringify: 3.0.1
+      i18next: 25.10.10(typescript@5.9.3)
+      react: 19.2.4
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
+      typescript: 5.9.3
+
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
@@ -5771,6 +5838,8 @@ snapshots:
       jsdom: 29.0.1
     transitivePeerDependencies:
       - msw
+
+  void-elements@3.1.0: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/frontend/travel-hub/pnpm-lock.yaml
+++ b/frontend/travel-hub/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       i18next:
         specifier: ^25.0.0
         version: 25.10.10(typescript@5.9.3)
-      i18next-browser-languagedetector:
-        specifier: ^8.0.0
-        version: 8.2.1
       next:
         specifier: 16.2.0
         version: 16.2.0(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1903,9 +1900,6 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
-
-  i18next-browser-languagedetector@8.2.1:
-    resolution: {integrity: sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==}
 
   i18next@25.10.10:
     resolution: {integrity: sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==}
@@ -4798,10 +4792,6 @@ snapshots:
       void-elements: 3.1.0
 
   husky@9.1.7: {}
-
-  i18next-browser-languagedetector@8.2.1:
-    dependencies:
-      '@babel/runtime': 7.29.2
 
   i18next@25.10.10(typescript@5.9.3):
     dependencies:

--- a/frontend/travel-hub/vitest.config.mts
+++ b/frontend/travel-hub/vitest.config.mts
@@ -7,6 +7,7 @@ export default defineConfig({
     tsconfigPaths: true,
   },
   test: {
+    setupFiles: ['./vitest.setup.ts'],
     environment: 'jsdom',
     globals: true,
     coverage: {

--- a/frontend/travel-hub/vitest.setup.ts
+++ b/frontend/travel-hub/vitest.setup.ts
@@ -1,0 +1,8 @@
+import { beforeEach } from 'vitest';
+
+import i18n from '@/lib/i18n/client';
+import { defaultLocale } from '@/lib/i18n/settings';
+
+beforeEach(async () => {
+  await i18n.changeLanguage(defaultLocale);
+});


### PR DESCRIPTION
# Resumen
Implementación de internacionalización con i18next y react-i18next para inglés (EE. UU.) (en-US) y español de Colombia (es-CO) en la app TravelHub (frontend/travel-hub).

# Cambios principales
- Traducciones en lib/i18n/locales/en-US/common.json y es-CO/common.json, con I18nProvider en el layout.
- Textos de navegación, home, búsqueda, filtros, pie de página y página de búsqueda conectados a t(...).
- Sincronización post-hidración (LanguageSync): idioma fijo en servidor y primer render del cliente (en-US) para evitar errores  de hidratación; después se aplica preferencia guardada en localStorage o idioma del navegador.0
- Tests actualizados con renderWithI18n y documentación en frontend/README.md sobre cómo añadir strings.

# Cómo probar
- pnpm dev en frontend/travel-hub, alternar idioma en la barra y comprobar textos y ausencia de avisos de hidratación.
- pnpm test run y pnpm build.

# Demo
https://github.com/user-attachments/assets/a47ca464-934c-478f-972d-4343edb694fd

