### PR TITLE
Agregando barra de navegacion y login para managers

### DIFF
--- a/backend/services/auth/app/adapters/inbound/api/login.py
+++ b/backend/services/auth/app/adapters/inbound/api/login.py
@@ -27,6 +27,14 @@ def _set_token_cookie(response: Response, token: str) -> None:
     )
 
 
+def _clear_token_cookie(response: Response) -> None:
+    response.delete_cookie(
+        key="access_token",
+        secure=not settings.DEBUG,
+        samesite="lax",
+    )
+
+
 @router.post("/login")
 async def login(
     request: LoginRequest,
@@ -71,3 +79,8 @@ async def me(
 
     use_case = get_validate_token_use_case(token)
     return use_case.execute(access_token)
+
+
+@router.post("/logout", status_code=204)
+async def logout(response: Response):
+    _clear_token_cookie(response)

--- a/backend/services/auth/tests/test_login.py
+++ b/backend/services/auth/tests/test_login.py
@@ -119,3 +119,13 @@ class TestMe:
 
         resp = client.get("/api/v1/auth/me", cookies={"access_token": "invalid-token"})
         assert resp.status_code == 401
+
+
+class TestLogout:
+    def test_logout_clears_cookie(self, client):
+        resp = client.post("/api/v1/auth/logout")
+
+        assert resp.status_code == 204
+        set_cookie = resp.headers.get("set-cookie", "")
+        assert "access_token=" in set_cookie
+        assert "Max-Age=0" in set_cookie

--- a/frontend/travel-hub/app/(auth)/login/manager/page.tsx
+++ b/frontend/travel-hub/app/(auth)/login/manager/page.tsx
@@ -1,3 +1,418 @@
+'use client';
+
+import { Suspense, useState } from 'react';
+
+import NextLink from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import { loginUser } from '@/app/lib/api/auth';
+import { tokens as th } from '@/lib/theme/tokens';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+import MailOutlineIcon from '@mui/icons-material/MailOutline';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
+import MuiLink from '@mui/material/Link';
+import Snackbar from '@mui/material/Snackbar';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import { useTranslation } from 'react-i18next';
+
+const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+
+interface FormValues {
+  email: string;
+  password: string;
+}
+
+interface FormErrors {
+  email?: string;
+  password?: string;
+}
+
+function validate(values: FormValues): FormErrors {
+  const errors: FormErrors = {};
+  if (!values.email) {
+    errors.email = 'Email is required';
+  } else if (!EMAIL_REGEX.test(values.email)) {
+    errors.email = 'Enter a valid email address';
+  }
+  if (!values.password) {
+    errors.password = 'Password is required';
+  }
+  return errors;
+}
+
+type SnackbarState = { open: boolean; message: string; severity: 'success' | 'error' };
+
+function inputSx(hasError: boolean) {
+  return {
+    '& .MuiOutlinedInput-root': {
+      borderRadius: '12px',
+      height: '48px',
+      bgcolor: th.surface.muted,
+      '& fieldset': { borderColor: hasError ? th.state.error : th.border.default },
+      '&:hover fieldset': { borderColor: hasError ? th.state.error : th.border.inputHover },
+      '&.Mui-focused fieldset': {
+        borderColor: hasError ? th.state.error : th.brand.primary,
+        borderWidth: 2,
+      },
+      '&.Mui-error fieldset': { borderColor: th.state.error },
+    },
+    '& .MuiInputBase-input': {
+      fontSize: '14px',
+      color: th.ink.charcoal,
+      '&::placeholder': { color: th.text.muted, opacity: 1 },
+    },
+    '& .MuiFormHelperText-root': { mx: 0, mt: '4px', fontSize: '12px' },
+  };
+}
+
+function ManagerLoginForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const redirectTo = searchParams.get('redirect') ?? '/manager';
+  const { t } = useTranslation();
+
+  const [values, setValues] = useState<FormValues>({ email: '', password: '' });
+  const [touched, setTouched] = useState<Partial<Record<keyof FormValues, boolean>>>({});
+  const [showPassword, setShowPassword] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [snackbar, setSnackbar] = useState<SnackbarState>({
+    open: false,
+    message: '',
+    severity: 'success',
+  });
+
+  const errors = validate(values);
+  const formIsInvalid = Object.keys(errors).length > 0;
+
+  function handleChange(field: keyof FormValues) {
+    return (e: React.ChangeEvent<HTMLInputElement>) =>
+      setValues((prev) => ({ ...prev, [field]: e.target.value }));
+  }
+
+  function handleBlur(field: keyof FormValues) {
+    return () => setTouched((prev) => ({ ...prev, [field]: true }));
+  }
+
+  function closeSnackbar() {
+    setSnackbar((prev) => ({ ...prev, open: false }));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setTouched({ email: true, password: true });
+    if (formIsInvalid) return;
+
+    setLoading(true);
+    try {
+      await loginUser(values.email, values.password);
+      setSnackbar({ open: true, message: 'Welcome back! Redirecting…', severity: 'success' });
+      setTimeout(() => router.push(redirectTo), 1200);
+    } catch {
+      setSnackbar({
+        open: true,
+        message: 'The email or password is not valid. Please try again.',
+        severity: 'error',
+      });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="bg-th-surface-page-cool flex flex-col items-center justify-center px-4 py-[100px] min-h-screen">
+      <Box maxWidth={448} width="100%" display="flex" flexDirection="column" gap={3}>
+        {/* Card */}
+        <Box
+          sx={{
+            bgcolor: 'white',
+            border: `1px solid ${th.surface.pageCool}`,
+            borderRadius: '16px',
+            boxShadow: '0px 20px 25px -5px rgba(0,0,0,0.1), 0px 8px 10px -6px rgba(0,0,0,0.1)',
+            width: '100%',
+          }}
+        >
+          {/* Header */}
+          <Box px={5} pt={5} display="flex" flexDirection="column" alignItems="center">
+            <Box
+              sx={{
+                bgcolor: 'rgba(14,165,233,0.1)',
+                borderRadius: '9999px',
+                width: 48,
+                height: 48,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                mb: 2,
+              }}
+            >
+              <LockOutlinedIcon sx={{ color: 'primary.main', fontSize: 22 }} />
+            </Box>
+
+            <Typography
+              variant="h2"
+              sx={{
+                fontWeight: 700,
+                fontSize: '24px',
+                color: 'text.primary',
+                lineHeight: '32px',
+                textAlign: 'center',
+              }}
+            >
+              Welcome to your next stay
+            </Typography>
+            <Typography
+              sx={{
+                color: 'text.secondary',
+                fontSize: '14px',
+                lineHeight: '20px',
+                textAlign: 'center',
+                mt: 0.5,
+                mb: 3,
+              }}
+            >
+              Plan your dream getaway with TravelHub.
+            </Typography>
+          </Box>
+
+          {/* Form */}
+          <Box
+            component="form"
+            onSubmit={handleSubmit}
+            noValidate
+            px={5}
+            pb={5}
+            display="flex"
+            flexDirection="column"
+            gap={2.5}
+          >
+            {/* Email */}
+            <Box>
+              <Typography
+                component="label"
+                htmlFor="email"
+                sx={{
+                  fontWeight: 500,
+                  fontSize: '12px',
+                  color: 'text.secondary',
+                  display: 'block',
+                  mb: '4px',
+                }}
+              >
+                Email address
+              </Typography>
+              <TextField
+                id="email"
+                type="email"
+                placeholder="name@example.com"
+                autoComplete="email"
+                fullWidth
+                value={values.email}
+                onChange={handleChange('email')}
+                onBlur={handleBlur('email')}
+                error={!!(touched.email && errors.email)}
+                helperText={touched.email ? errors.email : undefined}
+                slotProps={{
+                  input: {
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <MailOutlineIcon sx={{ color: 'text.secondary', fontSize: 16 }} />
+                      </InputAdornment>
+                    ),
+                  },
+                }}
+                sx={inputSx(!!(touched.email && errors.email))}
+              />
+            </Box>
+
+            {/* Password */}
+            <Box>
+              <Typography
+                component="label"
+                htmlFor="password"
+                sx={{
+                  fontWeight: 500,
+                  fontSize: '12px',
+                  color: 'text.secondary',
+                  display: 'block',
+                  mb: '4px',
+                }}
+              >
+                Password
+              </Typography>
+              <TextField
+                id="password"
+                type={showPassword ? 'text' : 'password'}
+                placeholder="••••••••"
+                autoComplete="current-password"
+                fullWidth
+                value={values.password}
+                onChange={handleChange('password')}
+                onBlur={handleBlur('password')}
+                error={!!(touched.password && errors.password)}
+                helperText={touched.password ? errors.password : undefined}
+                slotProps={{
+                  input: {
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <LockOutlinedIcon sx={{ color: 'text.secondary', fontSize: 15 }} />
+                      </InputAdornment>
+                    ),
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <IconButton
+                          aria-label={showPassword ? 'Hide password' : 'Show password'}
+                          onClick={() => setShowPassword((v) => !v)}
+                          edge="end"
+                          size="small"
+                          tabIndex={-1}
+                          sx={{ color: 'text.secondary', mr: '-4px' }}
+                        >
+                          {showPassword ? (
+                            <VisibilityIcon sx={{ fontSize: 17 }} />
+                          ) : (
+                            <VisibilityOffIcon sx={{ fontSize: 17 }} />
+                          )}
+                        </IconButton>
+                      </InputAdornment>
+                    ),
+                  },
+                }}
+                sx={inputSx(!!(touched.password && errors.password))}
+              />
+            </Box>
+
+            {/* Submit */}
+            <Button
+              type="submit"
+              variant="contained"
+              fullWidth
+              disabled={loading || formIsInvalid}
+              endIcon={!loading && <ArrowForwardIcon sx={{ fontSize: '16px !important' }} />}
+              sx={{
+                height: 52,
+                borderRadius: '12px',
+                bgcolor: 'primary.main',
+                fontWeight: 600,
+                fontSize: '16px',
+                textTransform: 'none',
+                letterSpacing: 0,
+                boxShadow:
+                  '0px 10px 15px -3px rgba(14,165,233,0.3), 0px 4px 6px -4px rgba(14,165,233,0.3)',
+                '&:hover': { bgcolor: th.brand.primaryHover, boxShadow: 'none' },
+                '&:active': { bgcolor: th.brand.primaryActive },
+                '&.Mui-disabled': { bgcolor: 'primary.main', color: 'white', opacity: 0.6 },
+              }}
+            >
+              {loading ? (
+                <Box display="flex" alignItems="center" gap={1}>
+                  <CircularProgress
+                    aria-label={t('a11y.loading')}
+                    size={18}
+                    sx={{ color: 'white' }}
+                  />
+                  <span>Signing in…</span>
+                </Box>
+              ) : (
+                'Continue'
+              )}
+            </Button>
+
+            {/* Create account link */}
+            <Box textAlign="center">
+              <MuiLink
+                component={NextLink}
+                href="/register/manager"
+                underline="none"
+                sx={{ color: 'text.secondary', fontSize: '14px' }}
+              >
+                Don&apos;t have an account?{' '}
+                <Box component="span" sx={{ fontWeight: 700, color: 'primary.dark' }}>
+                  Create Account
+                </Box>
+              </MuiLink>
+            </Box>
+
+            {/* Security badge + Terms */}
+            <Box display="flex" flexDirection="column" gap={1.5} mt={0.5}>
+              <Box display="flex" alignItems="center" justifyContent="center" gap={0.5}>
+                <LockOutlinedIcon sx={{ color: '#16a34a', fontSize: 14 }} />
+                <Typography sx={{ color: '#16a34a', fontSize: '12px', fontWeight: 500 }}>
+                  Your data is secured with 256-bit encryption
+                </Typography>
+              </Box>
+              <Typography
+                sx={{
+                  color: 'text.secondary',
+                  fontSize: '12px',
+                  textAlign: 'center',
+                  lineHeight: '19.5px',
+                }}
+              >
+                By signing up, you agree to our{' '}
+                <MuiLink
+                  component={NextLink}
+                  href="#"
+                  underline="always"
+                  sx={{
+                    color: 'text.primary',
+                    fontSize: '12px',
+                    textDecorationColor: 'rgba(14,165,233,0.3)',
+                  }}
+                >
+                  Terms of Service
+                </MuiLink>
+                {' & '}
+                <MuiLink
+                  component={NextLink}
+                  href="#"
+                  underline="always"
+                  sx={{
+                    color: 'text.primary',
+                    fontSize: '12px',
+                    textDecorationColor: 'rgba(14,165,233,0.3)',
+                  }}
+                >
+                  Privacy Policy
+                </MuiLink>
+                .
+              </Typography>
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={4000}
+        onClose={closeSnackbar}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+      >
+        <Alert
+          onClose={closeSnackbar}
+          severity={snackbar.severity}
+          variant="filled"
+          sx={{ width: '100%', borderRadius: '12px' }}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </div>
+  );
+}
+
 export default function ManagerLoginPage() {
-  return <h1>Manager Login</h1>;
+  return (
+    <Suspense>
+      <ManagerLoginForm />
+    </Suspense>
+  );
 }

--- a/frontend/travel-hub/app/lib/api/auth.ts
+++ b/frontend/travel-hub/app/lib/api/auth.ts
@@ -57,3 +57,14 @@ export async function getMe(): Promise<AuthResponse | null> {
     return null;
   }
 }
+
+export async function logoutUser(): Promise<void> {
+  try {
+    await fetch(`${API_URL}/api/v1/auth/logout`, {
+      method: 'POST',
+      credentials: 'include',
+    });
+  } catch {
+    // Best-effort logout; caller should still navigate away.
+  }
+}

--- a/frontend/travel-hub/app/manager/layout.tsx
+++ b/frontend/travel-hub/app/manager/layout.tsx
@@ -1,11 +1,264 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { usePathname, useRouter } from 'next/navigation';
+
+import { getMe, logoutUser } from '@/app/lib/api/auth';
+import { tokens as th } from '@/lib/theme/tokens';
+import BarChartIcon from '@mui/icons-material/BarChart';
+import BarChartOutlinedIcon from '@mui/icons-material/BarChartOutlined';
+import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
+import CalendarTodayOutlinedIcon from '@mui/icons-material/CalendarTodayOutlined';
+import DashboardCustomizeIcon from '@mui/icons-material/DashboardCustomize';
+import DashboardCustomizeOutlinedIcon from '@mui/icons-material/DashboardCustomizeOutlined';
+import LogoutIcon from '@mui/icons-material/Logout';
+import NotificationsIcon from '@mui/icons-material/Notifications';
+import NotificationsNoneOutlinedIcon from '@mui/icons-material/NotificationsNoneOutlined';
+import TravelExploreIcon from '@mui/icons-material/TravelExplore';
+import { Box } from '@mui/material';
+import Button from '@mui/material/Button';
+import Divider from '@mui/material/Divider';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Typography from '@mui/material/Typography';
+import { useTranslation } from 'react-i18next';
+
 import AuthGuard from '../components/AuthGuard';
 
 export default function ManagerLayout({ children }: { children: React.ReactNode }) {
+  const { t } = useTranslation();
+  const pathname = usePathname();
+  const router = useRouter();
+  const [user, setUser] = useState<{ email: string; role: string } | null>(null);
+
+  useEffect(() => {
+    getMe()
+      .then(setUser)
+      .catch(() => setUser(null));
+  }, []);
+
+  const MENU_ITEMS = [
+    {
+      key: 'admin.navbar.dashboard',
+      icon: <DashboardCustomizeOutlinedIcon />,
+      activeIcon: <DashboardCustomizeIcon />,
+      href: '/manager',
+    },
+    {
+      key: 'admin.navbar.bookings',
+      icon: <CalendarTodayOutlinedIcon />,
+      activeIcon: <CalendarTodayIcon />,
+      href: '/manager/bookings',
+    },
+    {
+      key: 'admin.navbar.hotels',
+      icon: <DashboardCustomizeOutlinedIcon />,
+      activeIcon: <DashboardCustomizeIcon />,
+      href: '/manager/hotels',
+    },
+    {
+      key: 'admin.navbar.notifications',
+      icon: <NotificationsNoneOutlinedIcon />,
+      activeIcon: <NotificationsIcon />,
+      href: '/manager/notifications',
+    },
+    {
+      key: 'admin.navbar.reports',
+      icon: <BarChartOutlinedIcon />,
+      activeIcon: <BarChartIcon />,
+      href: '/manager/reports',
+    },
+  ];
+
+  function isActive(href: string) {
+    if (href === '/manager') {
+      return pathname === '/manager';
+    }
+    return pathname.startsWith(href);
+  }
+
+  function formatDisplayName(email: string) {
+    const localPart = email.split('@')[0] ?? email;
+    return localPart.replace(/[._-]+/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
+  }
+
+  function formatRole(role: string) {
+    if (role === 'ADMIN') return 'Super Admin';
+    if (role === 'HOTEL') return 'Hotel Partner';
+    if (role === 'AGENCY') return 'Agency Partner';
+    return role;
+  }
+
+  async function handleLogout() {
+    await logoutUser();
+    document.cookie = 'access_token=; Max-Age=0; path=/';
+    router.push('/');
+  }
+
   return (
     <AuthGuard>
       <div style={{ display: 'flex' }}>
-        <aside>Manager Sidebar</aside>
-        <main style={{ flex: 1 }}>{children}</main>
+        <aside>
+          <Box sx={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1.5,
+                px: 2,
+                py: 1.5,
+              }}
+            >
+              <Box
+                sx={{
+                  width: 28,
+                  height: 28,
+                  borderRadius: '12px',
+                  bgcolor: th.brand.accentOrangeSoft,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  flexShrink: 0,
+                }}
+              >
+                <TravelExploreIcon sx={{ fontSize: 22, color: th.brand.accentOrange }} />
+              </Box>
+              <Box>
+                <Typography
+                  variant="subtitle1"
+                  sx={{
+                    color: '#111827',
+                    fontWeight: 700,
+                    lineHeight: 1.2,
+                  }}
+                >
+                  {t('admin.navbar.title')}
+                </Typography>
+                <Typography
+                  variant="subtitle2"
+                  sx={{
+                    color: '#64748B',
+                    fontWeight: 500,
+                    lineHeight: 1.25,
+                  }}
+                >
+                  {t('admin.navbar.subtitle')}
+                </Typography>
+              </Box>
+            </Box>
+            <Divider />
+            <List sx={{ flex: 1 }} disablePadding>
+              {MENU_ITEMS.map((item, index) => (
+                <ListItem key={index} disablePadding sx={{ display: 'block' }}>
+                  <ListItemButton
+                    component="a"
+                    href={item.href}
+                    selected={isActive(item.href)}
+                    sx={{
+                      borderRadius: '10px',
+                      mx: 1,
+                      my: 0.5,
+                      color: th.text.secondary,
+                      '& .MuiListItemIcon-root': {
+                        minWidth: 36,
+                        color: th.text.secondary,
+                      },
+                      '& .MuiTypography-root': {
+                        fontWeight: 500,
+                      },
+                      '&.Mui-selected': {
+                        backgroundColor: th.brand.accentOrangeSoft,
+                        color: th.brand.accentOrangeFg,
+                      },
+                      '&.Mui-selected:hover': {
+                        backgroundColor: th.brand.accentOrangeSoft,
+                      },
+                      '&.Mui-selected .MuiListItemIcon-root': {
+                        color: th.brand.accentOrangeFg,
+                      },
+                      '&.Mui-selected .MuiTypography-root': {
+                        fontWeight: 700,
+                      },
+                    }}
+                  >
+                    <ListItemIcon>{isActive(item.href) ? item.activeIcon : item.icon}</ListItemIcon>
+                    <ListItemText primary={t(item.key)} />
+                  </ListItemButton>
+                </ListItem>
+              ))}
+            </List>
+
+            <Box sx={{ px: 2, pb: 2, pt: 1, mt: 'auto' }}>
+              <Button
+                type="button"
+                onClick={handleLogout}
+                fullWidth
+                variant="contained"
+                startIcon={<LogoutIcon />}
+                sx={{
+                  bgcolor: th.brand.accentOrange,
+                  color: '#111827',
+                  fontWeight: 700,
+                  textTransform: 'none',
+                  borderRadius: '10px',
+                  py: 1,
+                  '&:hover': {
+                    bgcolor: th.brand.accentOrange,
+                    filter: 'brightness(0.95)',
+                  },
+                }}
+              >
+                {t('nav.logOut')}
+              </Button>
+            </Box>
+          </Box>
+        </aside>
+        <main style={{ flex: 1, background: '#F8FAFC', minHeight: '100vh' }}>
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              alignItems: 'center',
+              px: 3,
+              py: 2,
+            }}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25 }}>
+              <Box
+                sx={{
+                  width: 40,
+                  height: 40,
+                  borderRadius: '50%',
+                  bgcolor: th.brand.accentOrangeSoft,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  flexShrink: 0,
+                  color: th.brand.accentOrangeFg,
+                  fontWeight: 700,
+                  fontSize: '0.9rem',
+                }}
+              >
+                {user ? formatDisplayName(user.email).slice(0, 2) : 'UA'}
+              </Box>
+
+              <Box sx={{ display: 'flex', flexDirection: 'column', lineHeight: 1.05 }}>
+                <Typography sx={{ fontWeight: 700, color: th.text.primary, fontSize: '0.95rem' }}>
+                  {user ? formatDisplayName(user.email) : 'TravelHub Admin'}
+                </Typography>
+                <Typography sx={{ fontWeight: 600, color: th.text.secondary, fontSize: '0.68rem' }}>
+                  {user ? formatRole(user.role) : 'Super Admin'}
+                </Typography>
+              </Box>
+            </Box>
+          </Box>
+
+          <Box sx={{ px: 3, pb: 3 }}>{children}</Box>
+        </main>
       </div>
     </AuthGuard>
   );

--- a/frontend/travel-hub/components/layout/Navbar.tsx
+++ b/frontend/travel-hub/components/layout/Navbar.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
 import NextLink from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 
-import { getMe } from '@/app/lib/api/auth';
+import { getMe, logoutUser } from '@/app/lib/api/auth';
 import { defaultLocale } from '@/lib/i18n/settings';
 import { tokens as th } from '@/lib/theme/tokens';
 import AccountCircleOutlinedIcon from '@mui/icons-material/AccountCircleOutlined';
@@ -36,8 +36,9 @@ export default function Navbar() {
       .catch(() => setUser(null));
   }, []);
 
-  function handleLogout() {
+  async function handleLogout() {
     setMenuAnchor(null);
+    await logoutUser();
     document.cookie = 'access_token=; Max-Age=0; path=/';
     setUser(null);
     router.push('/');

--- a/frontend/travel-hub/lib/i18n/locales/en-US/common.json
+++ b/frontend/travel-hub/lib/i18n/locales/en-US/common.json
@@ -211,6 +211,18 @@
     "noPendingBookings": "No pending bookings.",
     "noAvailability": "Not enough availability. You can offer an upgrade, change dates, or decline the booking."
   },
+  "admin": {
+    "navbar": {
+      "title": "TravelHub Admin",
+      "dashboard": "Dashboard",
+      "bookings": "Bookings",
+      "hotels": "My Hotels",
+      "notifications": "Notifications",
+      "reports": "Reports",
+      "subtitle": "Super Admin",
+      "logout": "Log Out"
+    }
+  },
   "common": {
     "cancel": "Cancel",
     "unknownError": "Unknown error"

--- a/frontend/travel-hub/lib/i18n/locales/es-CO/common.json
+++ b/frontend/travel-hub/lib/i18n/locales/es-CO/common.json
@@ -216,6 +216,18 @@
     "noPendingBookings": "No hay reservas pendientes.",
     "noAvailability": "No hay disponibilidad suficiente. Puede ofrecer upgrade, cambiar fechas o rechazar la reserva."
   },
+  "admin": {
+    "navbar": {
+      "title": "TravelHub Admin",
+      "dashboard": "Dashboard",
+      "bookings": "Reservas",
+      "hotels": "Mis Hoteles",
+      "notifications": "Notificaciones",
+      "reports": "Reportes",
+      "subtitle": "Super Admin",
+      "logOut": "Cerrar sesión"
+    }
+  },
   "common": {
     "cancel": "Cancelar",
     "unknownError": "Error desconocido"

--- a/frontend/travel-hub/lib/theme/tokens.ts
+++ b/frontend/travel-hub/lib/theme/tokens.ts
@@ -13,6 +13,8 @@ export const tokens = {
     primaryOnLight: '#0369A1',
     /** Manager selected nav accent */
     accentOrange: '#EC5B13',
+    /** Darker orange for text/icons on light orange backgrounds */
+    accentOrangeFg: '#9A3412',
     /** 10% alpha background for accentOrange */
     accentOrangeSoft: '#EC5B131A',
   },

--- a/frontend/travel-hub/lib/theme/tokens.ts
+++ b/frontend/travel-hub/lib/theme/tokens.ts
@@ -11,6 +11,10 @@ export const tokens = {
     primaryActive: '#0369A1',
     /** Sky 700 — text / links on white (≥4.5:1 for 14px body) */
     primaryOnLight: '#0369A1',
+    /** Manager selected nav accent */
+    accentOrange: '#EC5B13',
+    /** 10% alpha background for accentOrange */
+    accentOrangeSoft: '#EC5B131A',
   },
   text: {
     primary: '#111827',


### PR DESCRIPTION
Se actualizó la interfaz del área de manager para mejorar la consistencia visual, accesibilidad y sesión de usuario. Ahora el sidebar usa la estructura correcta de listas, resalta la navegación activa con el color naranja del diseño y muestra el nombre/información del usuario en la parte superior sin incluir la barra de búsqueda.

También se corrigió el logout para cerrar sesión de forma real llamando al endpoint de auth, de modo que la cookie se elimina en el servidor y el usuario no permanece autenticado al refrescar la página.

# Preview
<img width="2341" height="1332" alt="image" src="https://github.com/user-attachments/assets/f0d1177b-f962-41b4-8fa3-2ce3e9796bac" />

